### PR TITLE
feature(annotations): toggle annotations YAML

### DIFF
--- a/feature_annotations.yaml
+++ b/feature_annotations.yaml
@@ -1,0 +1,27 @@
+# This code-annotations configuration file supports OEP-17, Feature Toggles.
+
+source_path: ./
+report_path: reports
+safelist_path: .annotation_safe_list.yml
+coverage_target: 50.0
+annotations:
+  documented_elsewhere:
+    - ".. documented_elsewhere_name:":
+  feature_toggle:
+    - ".. toggle_name:":
+    - ".. toggle_type:":
+        choices: [switch, rollout, group, ConfigurationModel, feature_flag]
+    - ".. toggle_default:":
+    - ".. toggle_description:":
+    - ".. toggle_category:":
+    - ".. toggle_use_cases:":
+        choices: [incremental_release, launch_date, monitored_rollout, graceful_degradation, beta_testing, vip, opt_out, open_edx]
+    - ".. toggle_creation_date:":
+    - ".. toggle_expiration_date:":
+    - ".. toggle_warnings:":
+    - ".. toggle_tickets:":
+    - ".. toggle_status:":
+extensions:
+    python:
+        - py
+rst_template: doc.rst.j2


### PR DESCRIPTION
Originally in https://github.com/edx/edx-platform/pull/19715 .

**How to use this file:**

1. clone the edx/code-annotations repo

1. checkout the nedbat/docgen branch (unless it's merged to master already)

1. `pip install -e .`    # in the code-annotations repo

1. In the edx-platform repo: `$ code_annotations static_find_annotations --config_file ../edx-toggles/feature_annotations.yaml`
