### PR TITLE
generate annotation docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,12 @@
 
 language: python
 
-python:
-  - 2.7
-  - 3.6
-
-env:
-  - TOXENV=django18
-  - TOXENV=django111
-  - TOXENV=django20
-
 matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
   include:
+    - python: 2.7
+      env: TOXENV=py27
     - python: 3.6
-      env: TOXENV=quality
-    - python: 3.6
-      env: TOXENV=docs
-    - python: 3.6
-      env: TOXENV=pii_check
+      env: TOXENV=py36
 
 cache:
   - pip

--- a/scripts/tests/test_feature_toggle_report_generator.py
+++ b/scripts/tests/test_feature_toggle_report_generator.py
@@ -89,7 +89,7 @@ def test_adding_annoation_links():
 
     ida._add_annotation_links_to_toggle_state(annotation_groups)
 
-    link = 'my-ida/index.rst#path-to-source-code-py-2'
+    link = 'my-ida/index.rst#index-rst-path-to-source-code-py-2'
     assert ida.toggle_states['waffle.switch'][1].annotation_link == link
 
 

--- a/templates/ida_base.tpl
+++ b/templates/ida_base.tpl
@@ -8,7 +8,9 @@ Feature Toggle Data for {{ ida.name }}
 
 {% if ida.annotation_report_path %}
 
-* code annotation report: {{ ida.annotation_report_path }}
+.. _code annotation report: {{ ida.name }}/index.rst
+
+* `code annotation report`_
 
 {% else %}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-django{18,111},py36-django20
+envlist = {py27,py36}
 
 [doc8]
 max-line-length = 120
@@ -29,15 +29,11 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 match-dir = (?!migrations)
 
 [pytest]
-DJANGO_SETTINGS_MODULE = test_settings
-addopts = --cov edx_toggles --cov-report term-missing --cov-report xml
+addopts = --cov scripts --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt
 commands =
     py.test {posargs}


### PR DESCRIPTION
This makes a call to `code_annotations` to create the annotation docs for each IDA, and bundle them into their own sub-directory.