### PR TITLE
fix code annotation config file

### DIFF
--- a/feature_toggle_annotations.yaml
+++ b/feature_toggle_annotations.yaml
@@ -11,7 +11,7 @@ annotations:
   feature_toggle:
     - ".. toggle_name:":
     - ".. toggle_type:":
-        choices: [switch, rollout, group, waffle_flag, configuration_model]
+        choices: [waffle_flag, waffle_sample, waffle_switch, rollout, group, configuration_model]
     - ".. toggle_default:":
     - ".. toggle_description:":
     - ".. toggle_category:":

--- a/feature_toggle_annotations.yaml
+++ b/feature_toggle_annotations.yaml
@@ -11,9 +11,7 @@ annotations:
   feature_toggle:
     - ".. toggle_name:":
     - ".. toggle_type:":
-        choices: [switch, rollout, group, waffle_flag]
-    - ".. toggle_implementation:":
-        choices: [ConfigurationModel, CourseWaffleFlag, WaffleFlag, WaffleSwitch, DjangoSetting]
+        choices: [switch, rollout, group, waffle_flag, configuration_model]
     - ".. toggle_default:":
     - ".. toggle_description:":
     - ".. toggle_category:":


### PR DESCRIPTION
There seems to be an unresolved discussion concerning which annotations should be used for feature toggles (https://github.com/edx/edx-toggles/pull/3). In favor of getting this tooling live, I have removed the `toggle_implementation` annotation from the configuration file, which unblocks the feature toggle report generator utility. Dev teams can reassess which annotations are needed once everything is in place.