### PR TITLE
use env var to specify db name

### DIFF
--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -58,6 +58,11 @@ environment variables (the defaults work with devstack):
 * DB_HOST
 * DB_PORT
 
+Additionally, you must set an environment variable to specify the database
+name for each IDA that you are querying about, in following form:
+<ida_name>_DB. For example:
+* LMS_DB
+
 Usage:
 ------
 

--- a/scripts/gather_feature_toggle_state.py
+++ b/scripts/gather_feature_toggle_state.py
@@ -138,7 +138,7 @@ def main(output_path):
     idas = [
         {
             'app': 'lms',
-            'database': 'edxapp',
+            'database': os.getenv('LMS_DB', 'edxapp'),
             'table_names': [
                 'waffle_flag', 'waffle_switch', 'waffle_sample'
             ]


### PR DESCRIPTION
The gather feature toggle state job was failing because it couldn't connect to the right database. The read replica uses a different db name than devstack. This allows you to set an environment variable for the LMS (the only IDA used for now).

Re: https://openedx.atlassian.net/browse/DEVOPS-9326