### PR TITLE
change toggle_type to toggle_implementation

### DIFF
--- a/feature_toggle_annotations.yaml
+++ b/feature_toggle_annotations.yaml
@@ -10,8 +10,8 @@ annotations:
     - ".. documented_elsewhere_name:":
   feature_toggle:
     - ".. toggle_name:":
-    - ".. toggle_type:":
-        choices: [waffle_flag, waffle_sample, waffle_switch, rollout, group, configuration_model]
+    - ".. toggle_implementation:":
+        choices: [WaffleFlag, WaffleSample, WaffleSwitch, CourseWaffleFlag, ConfigurationModel, DjangoSetting]
     - ".. toggle_default:":
     - ".. toggle_description:":
     - ".. toggle_category:":


### PR DESCRIPTION
Following a conversation with @robrap, I have changed the annotation token used to specify how a toggle is implemented from `.. toggle_type` to `.. toggle_implementation`. This follows the ideas set out in https://github.com/edx/edx-toggles/pull/3. I have also changed the  implementation types to be `CamelCase` instead of `separated_by_underscore`.