### PR TITLE
Estute/fix annotation tokens

### DIFF
--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -447,10 +447,10 @@ def main(sql_dump_path, annotation_report_path, output_path, environment_name):
     confluence = create_confluence_connection()
     confluence_space_id = _get_env_var('CONFLUENCE_SPACE_ID')
     confluence_page_name = _get_env_var('CONFLUENCE_PAGE_NAME')
-    # publish_to_confluence(
-        # confluence, 'reports/feature_toggle_report.html', confluence_space_id,
-        # confluence_page_name
-    # )
+    publish_to_confluence(
+        confluence, 'reports/feature_toggle_report.html', confluence_space_id,
+        confluence_page_name
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/gather_feature_toggle_state.py
+++ b/scripts/gather_feature_toggle_state.py
@@ -83,7 +83,9 @@ def format_as_json_dump(data):
 
     json_data = []
     for table_name, rows in data.items():
-        formatted_table_name = re.sub('_', '.', table_name)
+        formatted_table_name = ''.join(
+            map(lambda s: s.title(), table_name.split('_'))
+        )
 
         for row in rows:
 

--- a/scripts/tests/test_feature_toggle_report_generator.py
+++ b/scripts/tests/test_feature_toggle_report_generator.py
@@ -5,12 +5,12 @@ from ..feature_toggle_report_generator import (
 
 def test_adding_annotation_data():
     ida = IDA('my-ida')
-    switch_1 = Toggle('the-first-waffle-switch', ToggleState('waffle.switch', {}))
-    switch_2 = Toggle('my-sample-switch', ToggleState('waffle.switch', {}))
-    switch_3 = Toggle('another-sample-switch', ToggleState('waffle.switch', {}))
-    flag_1 = Toggle('sample-flag', ToggleState('waffle.flag', {}))
-    ida.toggles['waffle.switch'] = [switch_1, switch_2, switch_3]
-    ida.toggles['waffle.flag'] = [flag_1]
+    switch_1 = Toggle('the-first-waffle-switch', ToggleState('WaffleSwitch', {}))
+    switch_2 = Toggle('my-sample-switch', ToggleState('WaffleSwitch', {}))
+    switch_3 = Toggle('another-sample-switch', ToggleState('WaffleSwitch', {}))
+    flag_1 = Toggle('sample-flag', ToggleState('WaffleFlag', {}))
+    ida.toggles['WaffleSwitch'] = [switch_1, switch_2, switch_3]
+    ida.toggles['WaffleFlag'] = [flag_1]
     annotation_groups = {
         'path/to/source/code.py': [
             # A feature toggle annotation, but not one we care about linking
@@ -23,7 +23,7 @@ def test_adding_annotation_data():
                 'report_group_id': 1,
             }, {
                 'annotation_data': ['ConfigurationModel'],
-                'annotation_token': '.. toggle_type:',
+                'annotation_token': '.. toggle_implementation:',
                 'filename': 'path/to/source/code.py',
                 'found_by': 'python',
                 'line_number': 462,
@@ -45,8 +45,8 @@ def test_adding_annotation_data():
                 'line_number': 561,
                 'report_group_id': 2,
             }, {
-                'annotation_data': ['waffle.switch'],
-                'annotation_token': '.. toggle_type:',
+                'annotation_data': ['WaffleSwitch'],
+                'annotation_token': '.. toggle_implementation:',
                 'filename': 'path/to/source/code.py',
                 'found_by': 'python',
                 'line_number': 562,
@@ -69,8 +69,8 @@ def test_adding_annotation_data():
                 'line_number': 661,
                 'report_group_id': 1,
             }, {
-                'annotation_data': ['waffle.switch'],
-                'annotation_token': '.. toggle_type:',
+                'annotation_data': ['WaffleSwitch'],
+                'annotation_token': '.. toggle_implementation:',
                 'filename': 'path/to/other/source/code.py',
                 'found_by': 'python',
                 'line_number': 662,
@@ -90,8 +90,8 @@ def test_adding_annotation_data():
                 'line_number': 761,
                 'report_group_id': 2,
             }, {
-                'annotation_data': ['waffle.switch'],
-                'annotation_token': '.. toggle_type:',
+                'annotation_data': ['WaffleSwitch'],
+                'annotation_token': '.. toggle_implementation:',
                 'filename': 'path/to/other/source/code.py',
                 'found_by': 'python',
                 'line_number': 762,
@@ -109,24 +109,24 @@ def test_adding_annotation_data():
 
     expected_data = {
         'name': 'my-sample-switch',
-        'type': ['waffle.switch'],
+        'implementation': ['WaffleSwitch'],
         'default': True,
     }
 
     ida._add_annotation_data_to_toggle_state(annotation_groups)
 
-    annotation = ida.toggles['waffle.switch'][1].annotations
+    annotation = ida.toggles['WaffleSwitch'][1].annotations
     assert annotation.report_group_id == 2
     assert annotation.line_range() == (561, 563)
     assert annotation._raw_annotation_data == expected_data
 
     expected_data = {
         'name': 'not-in-db',
-        'type': ['waffle.switch'],
+        'implementation': ['WaffleSwitch'],
         'default': True,
     }
 
-    annotation = ida.toggles['waffle.switch'][3].annotations
+    annotation = ida.toggles['WaffleSwitch'][3].annotations
     assert annotation.report_group_id == 2
     assert annotation.line_range() == (761, 763)
     assert annotation._raw_annotation_data == expected_data
@@ -134,7 +134,7 @@ def test_adding_annotation_data():
 
 def test_toggle_date_format():
     switch = ToggleState(
-        'waffle.switch',
+        'WaffleSwitch',
         {
             'note': 'blank',
             'created': '2019-04-23T14:21:44.765727+00:30',
@@ -150,7 +150,7 @@ def test_toggle_date_format():
 
 def test_toggle_state():
     flag = ToggleState(
-        'waffle.flag',
+        'WaffleFlag',
         {
             'note': 'blank',
             'created': '2019-04-23 14:21:44.765727+00:00',

--- a/templates/flag.tpl
+++ b/templates/flag.tpl
@@ -15,11 +15,11 @@
         <th>Description</th>
         <th>Category</th>
         <th>Use Cases</th>
-        <th>Type</th>
+        <th>Implementation</th>
         <th>Creation date</th>
         <th>Expiration date</th>
     </tr>
-    {% for toggle in ida.toggles['waffle.flag'] %}
+    {% for toggle in ida.toggles['WaffleFlag'] %}
         {% if toggle.state_msg == 'On' %}
             <tr style="background-color:#C3FDB8;">
         {% elif toggle.state_msg == 'Off' %}
@@ -62,7 +62,7 @@
                     </ul>
                 {% endif %}
             </td>
-            <td>{{ toggle.data_for_template('annotation', 'type') }}</td>
+            <td>{{ toggle.data_for_template('annotation', 'implementation') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'creation_date') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'expiration_date') }}</td>
         </tr>

--- a/templates/report.tpl
+++ b/templates/report.tpl
@@ -33,7 +33,7 @@ below will be colorized and displayed accorind the following example:
     <h1>{{ ida_name }}</h1>
 
     <h2>Waffle Flags</h2>
-    {% if ida.toggles['waffle.flag']  %}
+    {% if ida.toggles['WaffleFlag']  %}
         {% include 'flag.tpl' %}
     {% else %}
         No waffle flags detected for this IDA
@@ -41,7 +41,7 @@ below will be colorized and displayed accorind the following example:
 
 
     <h2>Waffle Switches</h2>
-    {% if ida.toggles['waffle.switch']  %}
+    {% if ida.toggles['WaffleSwitch']  %}
         {% include 'switch.tpl' %}
     {% else %}
         No waffle switches detected for this IDA

--- a/templates/switch.tpl
+++ b/templates/switch.tpl
@@ -7,11 +7,11 @@
         <th>Description</th>
         <th>Category</th>
         <th>Use Cases</th>
-        <th>Type</th>
+        <th>Implementation</th>
         <th>Creation date</th>
         <th>Expiration date</th>
     </tr>
-    {% for toggle in ida.toggles['waffle.switch'] %}
+    {% for toggle in ida.toggles['WaffleSwitch'] %}
         {% if toggle.state_msg == 'On' %}
             <tr style="background-color:#C3FDB8;">
         {% elif toggle.state_msg == 'Off' %}
@@ -26,7 +26,7 @@
             <td>{{ toggle.data_for_template('annotation', 'description') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'category') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'use_cases') }}</td>
-            <td>{{ toggle.data_for_template('annotation', 'type') }}</td>
+            <td>{{ toggle.data_for_template('annotation', 'implementation') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'creation_date') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'expiration_date') }}</td>
         </tr>


### PR DESCRIPTION
Following a conversation w/ @robrap, I changed the naming of some annotation tokens to conform to oep-17 better (https://github.com/edx/edx-toggles/pull/15). This requires some changes to how we collect and display this data.