### PR TITLE
add flag to optionally publish to confluence

### DIFF
--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -53,6 +53,7 @@ a data dump file for each ida that makes use of waffle feature toggles.
 
 NOTE: To run this against a real environment, you will need to set the following
 environment variables (the defaults work with devstack):
+
 * DB_USER
 * DB_PASSWORD
 * DB_HOST
@@ -74,9 +75,17 @@ values on the command line:
     * annotation-data: path to the code annotation data created above
     * reports: path to write report files into
     * environment: name of the environment/deployment that you are reporting on
+    * --publish: (optional) a flag to specify whether or not to publish
+      the resulting HTML report to Confluence
 
-NOTE: You must have the following environment variables set to be able to
-publish the resulting report to Confluence:
+For example:
+
+.. code:: bash
+
+    python feature_toggle_report_generator.py my_data my_annotations output_dir stage --publish
+
+NOTE: If you choose to publish to Confluence, you must have the following
+environment variables set to be able to do so:
 
 * CONFLUENCE_BASE_URL: the url of the confluence instance you are targeting. For
   example: https://my-company.atlassian.net

--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -497,20 +497,22 @@ def publish_to_confluence(confluence, report_path, confluence_space_id,
 @click.argument(
     'environment_name', required=True
 )
-def main(sql_dump_path, annotation_report_path, output_path, environment_name):
+@click.option('--publish', is_flag=True)
+def main(sql_dump_path, annotation_report_path, output_path, environment_name, publish):
     ida_names = ['lms']
     idas = {name: IDA(name) for name in ida_names}
     add_toggle_state_to_idas(idas, sql_dump_path)
     add_toggle_annotations_to_idas(idas, annotation_report_path)
     renderer = Renderer('templates', output_path)
     renderer.render_html_report(idas, environment_name)
-    confluence = create_confluence_connection()
-    confluence_space_id = _get_env_var('CONFLUENCE_SPACE_ID')
-    confluence_page_name = _get_env_var('CONFLUENCE_PAGE_NAME')
-    publish_to_confluence(
-        confluence, 'reports/feature_toggle_report.html', confluence_space_id,
-        confluence_page_name
-    )
+    if publish:
+        confluence = create_confluence_connection()
+        confluence_space_id = _get_env_var('CONFLUENCE_SPACE_ID')
+        confluence_page_name = _get_env_var('CONFLUENCE_PAGE_NAME')
+        publish_to_confluence(
+            confluence, 'reports/feature_toggle_report.html', confluence_space_id,
+            confluence_page_name
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a `click` flag to optionally publish the html report to Confluence, to make testing locally (and on Jenkins in the short-term) easier.