### PR TITLE
add users and groups to waffle flag status and display

### DIFF
--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -291,6 +291,14 @@ class ToggleState(object):
             else:
                 return False
 
+        def bool_for_null_lists(l):
+            if not l:
+                return False
+            else:
+                return any(
+                    map(lambda x: x not in ['null', 'Null', 'NULL', 'None'], l)
+                )
+
         if self.toggle_type == 'WaffleSwitch':
             return self._raw_state_data['active']
         elif self.toggle_type == 'WaffleFlag':
@@ -310,7 +318,9 @@ class ToggleState(object):
                     self._raw_state_data['staff'] or
                     self._raw_state_data['authenticated'] or
                     bool(self._raw_state_data['languages']) or
-                    self._raw_state_data['rollout']
+                    self._raw_state_data['rollout'] or
+                    bool_for_null_lists(self._raw_state_data['users']) or
+                    bool_for_null_lists(self._raw_state_data['groups'])
                 )
 
     def _prepare_state_data_for_template(self):
@@ -349,6 +359,10 @@ class ToggleState(object):
                 else:
                     everyone_string = "Unknown"
                 self._cleaned_state_data[k] = everyone_string
+            elif k in ['users', 'groups']:
+                self._cleaned_state_data[k] = len(filter(
+                    lambda x: x not in ['null', 'Null', 'NULL', 'None'], v
+                ))
             else:
                 self._cleaned_state_data[k] = v
 

--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -318,7 +318,6 @@ class ToggleState(object):
                     self._raw_state_data['staff'] or
                     self._raw_state_data['authenticated'] or
                     bool(self._raw_state_data['languages']) or
-                    self._raw_state_data['rollout'] or
                     bool_for_null_lists(self._raw_state_data['users']) or
                     bool_for_null_lists(self._raw_state_data['groups'])
                 )

--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -292,12 +292,12 @@ class ToggleState(object):
                 return False
 
         def bool_for_null_lists(l):
-            if not l:
-                return False
-            else:
+            if l:
                 return any(
                     map(lambda x: x not in ['null', 'Null', 'NULL', 'None'], l)
                 )
+            else:
+                return False
 
         if self.toggle_type == 'WaffleSwitch':
             return self._raw_state_data['active']

--- a/scripts/tests/test_feature_toggle_report_generator.py
+++ b/scripts/tests/test_feature_toggle_report_generator.py
@@ -162,7 +162,6 @@ def test_toggle_state():
             'staff': False,
             'authenticated': False,
             'languages': False,
-            'rollout': False,
             'users': ['NULL'],
             'groups': []
         }

--- a/scripts/tests/test_feature_toggle_report_generator.py
+++ b/scripts/tests/test_feature_toggle_report_generator.py
@@ -162,7 +162,9 @@ def test_toggle_state():
             'staff': False,
             'authenticated': False,
             'languages': False,
-            'rollout': False
+            'rollout': False,
+            'users': ['NULL'],
+            'groups': []
         }
     )
     assert not flag.state

--- a/templates/flag.tpl
+++ b/templates/flag.tpl
@@ -11,7 +11,6 @@
         <th>Users</th>
         <th>Groups</th>
         <th>Languages</th>
-        <th>Rollout</th>
         <th>First modified</th>
         <th>Last modified</th>
         <th>Description</th>
@@ -50,7 +49,6 @@
                     </ul>
                 {% endif %}
             </td>
-            <td>{{ toggle.data_for_template('state', 'rollout') }}</td>
             <td>{{ toggle.data_for_template('state', 'created') }}</td>
             <td>{{ toggle.data_for_template('state', 'modified') }}</td>
             <td>{{ toggle.data_for_template('annotation', 'description') }}</td>
@@ -75,5 +73,5 @@
 <p>
 * The 'Status' of a waffle flag is computed by combining the state
 of the following flag components: everyone, percent, testing
-superusers, staff, authenticated, languages, rollout
+superusers, staff, authenticated, languages
 </p>

--- a/templates/flag.tpl
+++ b/templates/flag.tpl
@@ -8,6 +8,8 @@
         <th>Superusers</th>
         <th>Staff</th>
         <th>Authenticated users</th>
+        <th>Users</th>
+        <th>Groups</th>
         <th>Languages</th>
         <th>Rollout</th>
         <th>First modified</th>
@@ -35,6 +37,8 @@
             <td>{{ toggle.data_for_template('state', 'superusers') }}</td>
             <td>{{ toggle.data_for_template('state', 'staff') }}</td>
             <td>{{ toggle.data_for_template('state', 'authenticated') }}</td>
+            <td>{{ toggle.data_for_template('state', 'users') }}</td>
+            <td>{{ toggle.data_for_template('state', 'groups') }}</td>
             <td>
                 {% if toggle.data_for_template('state', 'languages') == '-' %}
                     -


### PR DESCRIPTION
`users` and `groups` were erroneously left out of both the computed flag `status` and the report. I have added them back in.