### PR TITLE
Added support for python 3.8 and dropped Django support for older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
+python:
+- 3.5
+- 3.8
 
-matrix:
-  include:
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 3.6
-      env: TOXENV=py36
+env:
+- TOXENV=django22
+- TOXENV=quality
+- TOXENV=docs
+- TOXENV=pii_check
 
 cache:
   - pip
   
 before_install:
-  - pip install --upgrade pip
+  - pip install pip==20.0.2
 
 install:
   - pip install -r requirements/travis.txt
@@ -32,4 +34,5 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.5
     condition: '$TOXENV = quality'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
-Unreleased
-~~~~~~~~~~
+[0.2.0] - 2020-05-05
+~~~~~~~~~~~~~~~~~~~~
 
-*
+* Added support for python 3.8 and dropped support Django versions older than 2.2
 
 [0.1.0] - 2019-04-08
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,6 @@ from subprocess import check_call
 import edx_theme
 from django import setup as django_setup
 from django.conf import settings
-from django.utils import six
 
 
 def get_version(*file_paths):
@@ -502,5 +501,5 @@ def on_init(app):  # pylint: disable=unused-argument
 
 def setup(app):
     """Sphinx extension: run sphinx-apidoc."""
-    event = 'builder-inited' if six.PY3 else b'builder-inited'
+    event = 'builder-inited'
     app.connect(event, on_init)

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -4,6 +4,6 @@ Library and utilities for feature toggles.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 default_app_config = 'edx_toggles.apps.EdxTogglesConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this application
 
-Django>=1.11,<2.0          # Web application framework
+Django>=2.2                # Web application framework
 django-waffle==0.12.0      # pinned to match the version in edx/edx-platform

--- a/setup.py
+++ b/setup.py
@@ -88,15 +88,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}
+envlist = py35-django22,py38-django{22,30}
 
 [doc8]
 max-line-length = 120
@@ -34,6 +34,8 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
+    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -r{toxinidir}/requirements/test.txt
 commands =
     py.test {posargs}


### PR DESCRIPTION
this PR update tox and Travis configurations to 

- Add support for python 3.8
- drop support for Django versions older than 2.2

Relevant JIRA issue [here](https://openedx.atlassian.net/browse/BOM-1595).