### PR TITLE
Add V1 of a csv renderer for toggles report

### DIFF
--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -8,8 +8,7 @@ import click
 import jinja2
 
 from scripts.ida import IDA, add_toggle_state_to_idas, add_toggle_annotations_to_idas
-from scripts.renderers import HtmlRenderer
-
+from scripts.renderers import CsvRenderer
 
 
 @click.command()
@@ -37,16 +36,9 @@ def main(sql_dump_path, annotation_report_path, output_path, environment_name, s
     if show_state:
         add_toggle_state_to_idas(idas, sql_dump_path)
     add_toggle_annotations_to_idas(idas, annotation_report_path)
-    renderer = HtmlRenderer('templates', output_path)
-    renderer.render_html_report(idas, environment_name, show_state)
-    if publish:
-        confluence = create_confluence_connection()
-        confluence_space_id = _get_env_var('CONFLUENCE_SPACE_ID')
-        confluence_page_name = _get_env_var('CONFLUENCE_PAGE_NAME')
-        publish_to_confluence(
-            confluence, 'reports/feature_toggle_report.html', confluence_space_id,
-            confluence_page_name
-        )
+    renderer = CsvRenderer()
+    renderer.render_flag_csv_report(idas)
+    renderer.render_switch_csv_report(idas)
 
 
 if __name__ == '__main__':

--- a/scripts/renderers.py
+++ b/scripts/renderers.py
@@ -4,6 +4,8 @@
 import datetime
 import io
 import os
+import csv
+from collections import OrderedDict
 
 import click
 import jinja2
@@ -11,6 +13,46 @@ import jinja2
 
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+
+class CsvRenderer():
+    """
+    Used to output toggles+annotations data as CSS
+    """
+
+    def __init__(self):
+        pass
+
+    def render_flag_csv_report(self, idas):
+        flag_toggles = []
+        header = set()
+        for ida_name, ida in idas.items():
+            for flag_toggle in ida.toggles['WaffleFlag']:
+                data_dict = flag_toggles.full_data
+                header.union(set(data_dict.keys()))
+                flag_toggles.append(data_dict)
+        self.write_csv("test.csv", flag_toggles, header)
+
+    def render_switch_csv_report(self, idas):
+        flag_toggles = []
+        header = set()
+        for ida_name, ida in idas.items():
+            for flag_toggle in ida.toggles['WaffleSwitch']:
+                data_dict = flag_toggles.full_data
+                header.union(set(data_dict.keys()))
+                flag_toggles.append(data_dict)
+        self.write_csv("test.csv", flag_toggles, header)
+
+
+    def write_csv(file_name, data, fieldnames):
+        """
+        writes data_dict in file with name file_name
+        """
+        with open(file_name, "w") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for datum in data:
+                writer.writerow(datum)
 
 
 class HtmlRenderer():

--- a/scripts/renderers.py
+++ b/scripts/renderers.py
@@ -5,6 +5,7 @@ import datetime
 import io
 import os
 import csv
+import logging
 from collections import OrderedDict
 
 import click
@@ -28,23 +29,23 @@ class CsvRenderer():
         header = set()
         for ida_name, ida in idas.items():
             for flag_toggle in ida.toggles['WaffleFlag']:
-                data_dict = flag_toggles.full_data
-                header.union(set(data_dict.keys()))
+                data_dict = flag_toggle.full_data()
+                header = header.union(set(data_dict.keys()))
                 flag_toggles.append(data_dict)
-        self.write_csv("test.csv", flag_toggles, header)
+        self.write_csv("test_flag.csv", flag_toggles, header)
 
     def render_switch_csv_report(self, idas):
-        flag_toggles = []
+        switch_toggles = []
         header = set()
         for ida_name, ida in idas.items():
-            for flag_toggle in ida.toggles['WaffleSwitch']:
-                data_dict = flag_toggles.full_data
-                header.union(set(data_dict.keys()))
-                flag_toggles.append(data_dict)
-        self.write_csv("test.csv", flag_toggles, header)
+            for switch_toggle in ida.toggles['WaffleSwitch']:
+                data_dict = switch_toggle.full_data()
+                header = header.union(set(data_dict.keys()))
+                switch_toggles.append(data_dict)
+        self.write_csv("test_switch.csv", switch_toggles, header)
 
 
-    def write_csv(file_name, data, fieldnames):
+    def write_csv(self, file_name, data, fieldnames):
         """
         writes data_dict in file with name file_name
         """

--- a/scripts/toggles.py
+++ b/scripts/toggles.py
@@ -55,6 +55,17 @@ class Toggle:
             else:
                 return '-'
 
+    def full_data(self):
+        """
+        Returns a dict with all info on toggle state and annotations
+        """
+        full_data = {}
+        self.state._prepare_state_data_for_template()
+        full_data["state"] = self.state._cleaned_state_data
+        self.annotations._prepare_annotation_data_for_template()
+        full_data["annotation"] = self.annotations._cleaned_annotation_data
+
+
 
 class ToggleAnnotation(object):
     """

--- a/scripts/toggles.py
+++ b/scripts/toggles.py
@@ -3,7 +3,10 @@ Common classes to represent toggles withint IDAs.
 """
 import collections
 import re
+import logging
 
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 class Toggle:
     """
@@ -60,14 +63,20 @@ class Toggle:
         Returns a dict with all info on toggle state and annotations
         """
         full_data = {}
-        self.state._prepare_state_data_for_template()
-        for key, value in self.state._cleaned_state_data.items()
-            full_data["state_{}".format(key)] = value
-        self.annotations._prepare_annotation_data_for_template()
-        for key, value in self.annotations._cleaned_annotation_data.items():
-            full_data["annotation_{}".format(key)] = value
-        return full_data
+        if self.state is not None:
+            self.state._prepare_state_data_for_template()
+            for key, value in self.state._cleaned_state_data.items():
+                full_data["state_{}".format(key)] = value
+        else:
+            LOGGER.debug("{} Toggle's state is None".format(self.name))
 
+        if self.annotations is not None:
+            self.annotations._prepare_annotation_data_for_template()
+            for key, value in self.annotations._cleaned_annotation_data.items():
+                full_data["annotation_{}".format(key)] = value
+        else:
+            LOGGER.debug("{} Toggle's annotations is None".format(self.name))
+        return full_data
 
 
 class ToggleAnnotation(object):

--- a/scripts/toggles.py
+++ b/scripts/toggles.py
@@ -61,9 +61,12 @@ class Toggle:
         """
         full_data = {}
         self.state._prepare_state_data_for_template()
-        full_data["state"] = self.state._cleaned_state_data
+        for key, value in self.state._cleaned_state_data.items()
+            full_data["state_{}".format(key)] = value
         self.annotations._prepare_annotation_data_for_template()
-        full_data["annotation"] = self.annotations._cleaned_annotation_data
+        for key, value in self.annotations._cleaned_annotation_data.items():
+            full_data["annotation_{}".format(key)] = value
+        return full_data
 
 
 


### PR DESCRIPTION
CsvRenderer
- contains 2 functions: one to output WaffleFlag info csv, second to output Switch info csv
     - the two are different cause Switch and WaffleFlag seem to have very different info, so it did not make sense for both to be in same csv. If we eventually decide to combine the reports, it should be easy to do
