### PR TITLE
Add output for waffle flag course overrides (ARCHBOM-1364)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,13 +3,18 @@ Change Log
 
 ..
    All enhancements and patches to edx_toggles will be documented
-   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
    
-   This project adheres to Semantic Versioning (http://semver.org/).
+   This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
+
+Unreleased
+~~~~~~~~~~
+
+* Added output for waffle flag course overrides to data gatherer
 
 2020-07-23
 ~~~~~~~~~~
@@ -22,12 +27,12 @@ Change Log
 
 2020-06-30
 ~~~~~~~~~~
-* Added CsvResnderer
+* Added CsvRenderer
 * Removed confluence integration
 
 2020-06-29
 ~~~~~~~~~~
-* Moved HtmlRenderer to its onw file
+* Moved HtmlRenderer to its own file
     - getting files ready to add a CsvResnderer
 
 [0.2.0] - 2020-05-27

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Unreleased
 * Added output for waffle flag course overrides to data gatherer
 * Upgraded dependencies
 
+[NOTE: None of these versions have actually been released to PyPI, even though
+the version number has been bumped.]
+
 2020-07-23
 ~~~~~~~~~~
 * Added more options to scripts/feature_toggle_report_generator
@@ -49,7 +52,4 @@ Unreleased
 [0.1.0] - 2019-04-08
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Added
-_____
-
-* First release on PyPI.
+* Initial version

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
 ~~~~~~~~~~
 
 * Added output for waffle flag course overrides to data gatherer
+* Upgraded dependencies
 
 2020-07-23
 ~~~~~~~~~~

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,6 @@
 #    make upgrade
 #
 django-waffle==0.12.0     # via -r requirements/base.in
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,6 @@ code-annotations==0.3.3
 
 # stevedore > 1.32.0 does not work with Python 3.5
 stevedore==1.32.0
+
+# inflect 4.0.0 drops support for Python 3.5
+inflect<4.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,23 +8,24 @@ appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 atlassian-python-api==1.16.0  # via -r requirements/quality.txt
 attrs==19.3.0             # via -r requirements/quality.txt, pytest
-certifi==2020.4.5.2       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.3.3   # via -c requirements/constraints.txt, -r requirements/quality.txt
-codecov==2.1.7            # via -r requirements/travis.txt
-coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+codecov==2.1.8            # via -r requirements/travis.txt
+coverage==5.2             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 diff-cover==3.0.1         # via -r requirements/dev.in
-distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
+distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django-waffle==0.12.0     # via -r requirements/quality.txt
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, edx-i18n-tools
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, edx-i18n-tools
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.4.1           # via -r requirements/quality.txt
+edx-lint==1.5.0           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
-inflect==4.1.0            # via jinja2-pluralize
+idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
+inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
@@ -37,41 +38,42 @@ oauthlib==3.1.0           # via -r requirements/quality.txt, atlassian-python-ap
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
+pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
 pbr==5.4.5                # via -r requirements/quality.txt, stevedore
 pip-tools==5.2.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-py==1.8.2                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/quality.txt
 pytest-django==3.9.0      # via -r requirements/quality.txt
 pytest==5.4.3             # via -r requirements/quality.txt, pytest-cov, pytest-django
-python-slugify==4.0.0     # via -r requirements/quality.txt, code-annotations
+python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
 pytz==2020.1              # via -r requirements/quality.txt, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, atlassian-python-api
 requests==2.24.0          # via -r requirements/quality.txt, -r requirements/travis.txt, atlassian-python-api, codecov, requests-oauthlib
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, atlassian-python-api, diff-cover, edx-i18n-tools, edx-lint, packaging, pip-tools, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, atlassian-python-api, diff-cover, edx-i18n-tools, edx-lint, packaging, pathlib2, pip-tools, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations
 text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
 toml==0.10.1              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.15.2               # via -r requirements/travis.txt, tox-battery
+tox==3.18.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
-urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-virtualenv==20.0.23       # via -r requirements/travis.txt, tox
-wcwidth==0.2.4            # via -r requirements/quality.txt, pytest
+urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.0.27       # via -r requirements/travis.txt, tox
+wcwidth==0.2.5            # via -r requirements/quality.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,43 +9,44 @@ atlassian-python-api==1.16.0  # via -r requirements/test.txt
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 bleach==3.1.5             # via readme-renderer
-certifi==2020.4.5.2       # via -r requirements/test.txt, requests
+certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click==7.1.2              # via -r requirements/test.txt, code-annotations
 code-annotations==0.3.3   # via -c requirements/constraints.txt, -r requirements/test.txt
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
 django-waffle==0.12.0     # via -r requirements/test.txt
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-idna==2.9                 # via -r requirements/test.txt, requests
+idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.1  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, sphinx
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysql-connector-python-rf==2.2.2  # via -r requirements/test.txt
 oauthlib==3.1.0           # via -r requirements/test.txt, atlassian-python-api, requests-oauthlib
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.8.2                 # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 pytz==2020.1              # via -r requirements/test.txt, babel, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
 readme-renderer==26.0     # via -r requirements/doc.in
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, atlassian-python-api
 requests==2.24.0          # via -r requirements/test.txt, atlassian-python-api, requests-oauthlib, sphinx
 restructuredtext-lint==1.3.1  # via doc8
-six==1.15.0               # via -r requirements/test.txt, atlassian-python-api, bleach, doc8, edx-sphinx-theme, packaging, readme-renderer, stevedore
+six==1.15.0               # via -r requirements/test.txt, atlassian-python-api, bleach, doc8, edx-sphinx-theme, packaging, pathlib2, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.1.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -55,8 +56,8 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, doc8
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
-urllib3==1.25.9           # via -r requirements/test.txt, requests
-wcwidth==0.2.4            # via -r requirements/test.txt, pytest
+urllib3==1.25.10          # via -r requirements/test.txt, requests
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -7,17 +7,17 @@
 astroid==2.3.3            # via pylint, pylint-celery
 atlassian-python-api==1.16.0  # via -r requirements/test.txt
 attrs==19.3.0             # via -r requirements/test.txt, pytest
-certifi==2020.4.5.2       # via -r requirements/test.txt, requests
+certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.3.3   # via -c requirements/constraints.txt, -r requirements/test.txt
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
 django-waffle==0.12.0     # via -r requirements/test.txt
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
-edx-lint==1.4.1           # via -r requirements/quality.in
-idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/test.txt, pluggy, pytest
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
+edx-lint==1.5.0           # via -r requirements/quality.in
+idna==2.10                # via -r requirements/test.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
 lazy-object-proxy==1.4.3  # via astroid
@@ -27,31 +27,32 @@ more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysql-connector-python-rf==2.2.2  # via -r requirements/test.txt
 oauthlib==3.1.0           # via -r requirements/test.txt, atlassian-python-api, requests-oauthlib
 packaging==20.4           # via -r requirements/test.txt, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.8.2                 # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 pytz==2020.1              # via -r requirements/test.txt, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, atlassian-python-api
 requests==2.24.0          # via -r requirements/test.txt, atlassian-python-api, requests-oauthlib
-six==1.15.0               # via -r requirements/test.txt, astroid, atlassian-python-api, edx-lint, packaging, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, atlassian-python-api, edx-lint, packaging, pathlib2, stevedore
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 typed-ast==1.4.1          # via astroid
-urllib3==1.25.9           # via -r requirements/test.txt, requests
-wcwidth==0.2.4            # via -r requirements/test.txt, pytest
+urllib3==1.25.10          # via -r requirements/test.txt, requests
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -5,19 +5,19 @@
 #    make upgrade
 #
 atlassian-python-api==1.16.0  # via -r requirements/scripts.in
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via code-annotations
 code-annotations==0.3.3   # via -c requirements/constraints.txt, -r requirements/scripts.in
 django-waffle==0.12.0     # via -r requirements/base.txt
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations
-idna==2.9                 # via requests
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations
+idna==2.10                # via requests
 jinja2==2.11.2            # via code-annotations
 markupsafe==1.1.1         # via jinja2
 mysql-connector-python-rf==2.2.2  # via -r requirements/scripts.in
 oauthlib==3.1.0           # via atlassian-python-api, requests-oauthlib
 pbr==5.4.5                # via stevedore
-python-slugify==4.0.0     # via code-annotations
+python-slugify==4.0.1     # via code-annotations
 pytz==2020.1              # via -r requirements/base.txt, django
 pyyaml==5.3.1             # via code-annotations
 requests-oauthlib==1.3.0  # via atlassian-python-api
@@ -26,4 +26,4 @@ six==1.15.0               # via atlassian-python-api, stevedore
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, code-annotations
 text-unidecode==1.3       # via python-slugify
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,36 +6,37 @@
 #
 atlassian-python-api==1.16.0  # via -r requirements/scripts.txt
 attrs==19.3.0             # via pytest
-certifi==2020.4.5.2       # via -r requirements/scripts.txt, requests
+certifi==2020.6.20        # via -r requirements/scripts.txt, requests
 chardet==3.0.4            # via -r requirements/scripts.txt, requests
 click==7.1.2              # via -r requirements/scripts.txt, code-annotations
 code-annotations==0.3.3   # via -c requirements/constraints.txt, -r requirements/scripts.txt, -r requirements/test.in
-coverage==5.1             # via pytest-cov
+coverage==5.2             # via pytest-cov
 django-waffle==0.12.0     # via -r requirements/base.txt, -r requirements/scripts.txt
-idna==2.9                 # via -r requirements/scripts.txt, requests
-importlib-metadata==1.6.1  # via pluggy, pytest
+idna==2.10                # via -r requirements/scripts.txt, requests
+importlib-metadata==1.7.0  # via pluggy, pytest
 jinja2==2.11.2            # via -r requirements/scripts.txt, code-annotations
 markupsafe==1.1.1         # via -r requirements/scripts.txt, jinja2
 more-itertools==8.4.0     # via pytest
 mysql-connector-python-rf==2.2.2  # via -r requirements/scripts.txt
 oauthlib==3.1.0           # via -r requirements/scripts.txt, atlassian-python-api, requests-oauthlib
 packaging==20.4           # via pytest
+pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/scripts.txt, stevedore
 pluggy==0.13.1            # via pytest
-py==1.8.2                 # via pytest
+py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.3             # via pytest-cov, pytest-django
-python-slugify==4.0.0     # via -r requirements/scripts.txt, code-annotations
+python-slugify==4.0.1     # via -r requirements/scripts.txt, code-annotations
 pytz==2020.1              # via -r requirements/base.txt, -r requirements/scripts.txt, django
 pyyaml==5.3.1             # via -r requirements/scripts.txt, code-annotations
 requests-oauthlib==1.3.0  # via -r requirements/scripts.txt, atlassian-python-api
 requests==2.24.0          # via -r requirements/scripts.txt, atlassian-python-api, requests-oauthlib
-six==1.15.0               # via -r requirements/scripts.txt, atlassian-python-api, packaging, stevedore
+six==1.15.0               # via -r requirements/scripts.txt, atlassian-python-api, packaging, pathlib2, stevedore
 sqlparse==0.3.1           # via -r requirements/base.txt, -r requirements/scripts.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/scripts.txt, code-annotations
 text-unidecode==1.3       # via -r requirements/scripts.txt, python-slugify
-urllib3==1.25.9           # via -r requirements/scripts.txt, requests
-wcwidth==0.2.4            # via pytest
+urllib3==1.25.10          # via -r requirements/scripts.txt, requests
+wcwidth==0.2.5            # via pytest
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,23 +5,24 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.7            # via -r requirements/travis.in
-coverage==5.1             # via codecov
-distlib==0.3.0            # via virtualenv
+codecov==2.1.8            # via -r requirements/travis.in
+coverage==5.2             # via codecov
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.9                 # via requests
-importlib-metadata==1.6.1  # via pluggy, tox, virtualenv
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.2                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.15.2               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.9           # via requests
-virtualenv==20.0.23       # via tox
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata
+tox==3.18.0               # via -r requirements/travis.in, tox-battery
+urllib3==1.25.10          # via requests
+virtualenv==20.0.27       # via tox
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -61,8 +61,8 @@ The current state of certain feature toggles (i.e. django-waffle, waffle-utils)
 is not captured in the codebase, as it is decoupled from the deployment of
 code. Rather, it must read from the database of an application.
 
-Assuming you have a provisioned `devstack`_, run the following make commands to
-generate the feature toggle state data files.
+Assuming you have a provisioned `devstack`_, run the following make command
+in devstack to generate the feature toggle state data files.
 
 .. code:: bash
 

--- a/scripts/gather_feature_toggle_state.py
+++ b/scripts/gather_feature_toggle_state.py
@@ -132,7 +132,7 @@ def build_query(table_name):
         # record with the newest change_date for a given key is the
         # one in effect (this is the contract of ConfigurationModel).
         current_versions_subquery = (
-            "SELECT waffle_flag, course_id, MAX(change_date) AS max_change_date "
+            "SELECT waffle_flag, course_id, MAX(change_date) "
             "FROM waffle_utils_waffleflagcourseoverridemodel "
             "GROUP BY waffle_flag, course_id"
         )

--- a/scripts/gather_feature_toggle_state.py
+++ b/scripts/gather_feature_toggle_state.py
@@ -1,10 +1,10 @@
-# gather-feature-toggle-state.py
+# gather_feature_toggle_state.py
 
 # As part of the Feature Toggle Report Generator utility, this script queries
 # a database (i.e. Devstack MySQL container, read-replica) for data on the
 # state of feature toggles (i.e. waffle flags) in a set of idas (i.e. edxapp)
 # and write it to a JSON file. These are used as inputs to
-# https://github.com/edx/edx-toggles/blob/master/scripts/feature_toggle_report_generator.py
+# feature_toggle_report_generator.py
 
 
 
@@ -127,6 +127,21 @@ def build_query(table_name):
             "LEFT JOIN waffle_flag_groups ON waffle_flag.id=waffle_flag_groups.flag_id "
             "GROUP BY waffle_flag_users.flag_id, waffle_flag_groups.flag_id;"
         )
+    elif table_name == 'waffle_utils_waffleflagcourseoverridemodel':
+        # This model is keyed on waffle_flag and course_id, and the
+        # record with the newest change_date for a given key is the
+        # one in effect (this is the contract of ConfigurationModel).
+        current_versions_subquery = (
+            "SELECT waffle_flag, course_id, MAX(change_date) AS max_change_date "
+            "FROM waffle_utils_waffleflagcourseoverridemodel "
+            "GROUP BY waffle_flag, course_id"
+        )
+        # Get values for current versions, discarding any that are disabled.
+        query = (
+            "SELECT id, waffle_flag, course_id, override_choice "
+            "FROM waffle_utils_waffleflagcourseoverridemodel "
+            "WHERE (waffle_flag, course_id, change_date) IN (%s) AND enabled = true" % current_versions_subquery
+        )
     else:
         query = "SELECT * FROM {};".format(table_name)
     return query
@@ -143,7 +158,8 @@ def main(output_path):
             'app': 'lms',
             'database': os.getenv('LMS_DB', 'edxapp'),
             'table_names': [
-                'waffle_flag', 'waffle_switch', 'waffle_sample'
+                'waffle_flag', 'waffle_switch', 'waffle_sample',
+                'waffle_utils_waffleflagcourseoverridemodel',
             ]
         }
     ]


### PR DESCRIPTION
Also some cleanup in Changelog file.

**JIRA:** https://openedx.atlassian.net/browse/ARCHBOM-1364

**Testing instructions:**

1. Check out this branch
2. In devstack, add a course override at http://localhost:18000/admin/waffle_utils/waffleflagcourseoverridemodel/add/ with enabled=true, force on, flag=`foo.waffle.flag.bar`, course=`course-v1:edX+E2E-101+course`
3. Run `make feature-toggle-state` in provisioned devstack
4. Check output `feature-toggle-data/lms_waffle_utils.json`

Output should contain one record, like so:

```json
[
  {
    "model": "waffle_utils.waffleflagcourseoverridemodel",
    "pk": 1,
    "fields": {
      "change_date": "2020-07-23T22:24:44.483Z",
      "changed_by": 3,
      "enabled": true,
      "waffle_flag": "foo.waffle.flag.bar",
      "course_id": "course-v1:edX+E2E-101+course",
      "override_choice": "on"
    }
  }
]
```

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)