### PR TITLE
data keys now postfixed with either _a or _s

### DIFF
--- a/scripts/renderers.py
+++ b/scripts/renderers.py
@@ -4,6 +4,7 @@
 import datetime
 import io
 import os
+import re
 import csv
 import logging
 from collections import OrderedDict
@@ -84,7 +85,8 @@ class CsvRenderer():
             # setting key for keys with name to False causes them to appear first in header
             sort_by.append(False if "name" in key else True)
             # show states first
-            sort_by.append(False if "state" in key else True)
+            pattern = re.compile(".*_s$")
+            sort_by.append(False if pattern.search(key) else True)
             # finally sort by alphabetical order
             sort_by.append(key)
             return tuple(sort_by)

--- a/scripts/tests/test_renderer.py
+++ b/scripts/tests/test_renderer.py
@@ -46,12 +46,12 @@ def test_get_sorted_headers_from_toggles():
     - state data has priority, column titles with "state" in it
     - alphabetically
     """
-    unsorted_headers = ["env_name", "aaaaa", "ida_name", "bbbbb", "name", "state_not"]
+    unsorted_headers = ["env_name", "aaaaa", "ida_name", "bbbbb", "name", "not_s"]
     flattened_data = [{key:True for key in unsorted_headers} for num in range(20)]
     sorted_header = csv_renderer.get_sorted_headers_from_toggles(flattened_data)
     assert sorted_header[0] == "name"
     assert sorted_header[2] == "ida_name"
-    assert sorted_header[3] == "state_not"
+    assert sorted_header[3] == "not_s"
     assert sorted_header[5] == "bbbbb"
 
 def test_filter_and_sort_toggles_filtering():

--- a/scripts/toggles.py
+++ b/scripts/toggles.py
@@ -70,7 +70,8 @@ class Toggle:
             for key, value in self.state._cleaned_state_data.items():
                 if key == "name":
                     continue
-                full_data["state_{}".format(key)] = value
+                # data that is received from state data dump is postfixed with a "_s"
+                full_data["{}_s".format(key)] = value
         else:
             LOGGER.debug("{} Toggle's state is None".format(self.name))
 
@@ -79,7 +80,8 @@ class Toggle:
             for key, value in self.annotations._cleaned_annotation_data.items():
                 if key == "name":
                     continue
-                full_data["annotation_{}".format(key)] = value
+                # data that is received from annotations is postfixed with a "_a"
+                full_data["{}_a".format(key)] = value
         else:
             LOGGER.debug("{} Toggle's annotations is None".format(self.name))
         return full_data


### PR DESCRIPTION
Previously, I had prefixed data keys with either "annotation_" or "state_" to convey the source of data. This resulted in making the resulting csv reports very hard to read. Change to postfix "_a" and "_s" cause it should be less distracting. 

The alternative:
"a_" and "s_" prefix: I also considered this, but I think postfixes are better cause when quickly glancing through csv report, the key name is more important than its source.
