### PR TITLE
ARCHBOM-1392: fix CourseWaffleFlag issues

### DIFF
--- a/scripts/feature_toggle_report_generator.py
+++ b/scripts/feature_toggle_report_generator.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import datetime
-import io
 import os
 import re
 import yaml
@@ -9,7 +7,6 @@ import logging
 from collections import defaultdict
 
 import click
-import jinja2
 
 from scripts.ida_toggles import IDA, add_toggle_state_to_idas, add_toggle_annotations_to_idas
 from scripts.renderers import CsvRenderer

--- a/scripts/gather_feature_toggle_state.py
+++ b/scripts/gather_feature_toggle_state.py
@@ -11,10 +11,8 @@
 
 import datetime
 import decimal
-import io
 import json
 import os
-import re
 import shutil
 import sys
 

--- a/scripts/tests/test_toggles.py
+++ b/scripts/tests/test_toggles.py
@@ -1,5 +1,5 @@
-from scripts.ida_toggles import IDA
-from scripts.toggles import Toggle, ToggleState
+from scripts.toggles import ToggleState
+
 
 def test_toggle_date_format():
     switch = ToggleState(
@@ -18,7 +18,7 @@ def test_toggle_date_format():
 
 
 def test_toggle_state():
-    flag = ToggleState(
+    flag_state = ToggleState(
         'WaffleFlag',
         {
             'note': 'blank',
@@ -35,4 +35,5 @@ def test_toggle_state():
             'groups': []
         }
     )
-    assert not flag.state
+    # TODO: Either kill the .state property, or add better tests.
+    assert not flag_state.state

--- a/scripts/toggles.py
+++ b/scripts/toggles.py
@@ -22,31 +22,23 @@ class ToggleTypes(Enum):
     UNKNOWN = "model name not recognized"
 
     @classmethod
-    def get_toggle_type_from_table_name(cls, table_name):
+    def get_toggle_type_from_model_name(cls, model_name):
         """
         Assign toggle type to model types
         """
 
         # convert sql dump model name to annotation report toggle type name
-        # this is usually the case with just devstack data dump, particularly from ecommerce
-        if table_name == "waffle.flag":
-            toggle_type = cls.WAFFLE_FLAG
-        elif table_name == "waffle.switch":
-            toggle_type = cls.WAFFLE_SWITCH
-        elif table_name == "waffle.sample":
-            toggle_type = cls.WAFFLE_SAMPLE
-        elif table_name == "WaffleUtilsWaffleflagcourseoverridemodel":
+        if model_name == "WaffleUtilsWaffleflagcourseoverridemodel":
             toggle_type = cls.COURSE_WAFFLE_FLAG
         else:
             try:
-                toggle_type = cls(table_name)
+                toggle_type = cls(model_name)
             except:
                 LOGGER.warning(
-                'Name of model not recognized: {}'.format(table_name)
+                'Name of model not recognized: {}'.format(model_name)
                 )
                 toggle_type = cls.UNKNOWN
         return toggle_type
-
 
 
 class Toggle:
@@ -164,28 +156,34 @@ class ToggleState(object):
 
     def __init__(self, toggle_type, data):
         self.toggle_type = toggle_type
-        self._raw_state_data = data
+        self._raw_state_data = collections.defaultdict(str, data)
         self._cleaned_state_data = collections.defaultdict(str)
+
+    def update_data(self, data):
+        """
+        Updates the state data.
+        """
+        self._raw_state_data.update(data)
 
     def get_datum(self, key, cleaned=True):
         """
-        get data from either _raw_state_data dict or _cleaned_state_data dict
+        Get data from either _raw_state_data dict or _cleaned_state_data dict
 
         Arguments:
             key: the key name for data
             cleaned: Whether to get datum from _raw_state_data dict or _cleaned_state_data
-                By default, this will get datum to _cleaned_state_data:
+                By default, this will get datum from _cleaned_state_data:
         """
         if cleaned:
             self._prepare_state_data()
-            return self._cleaned_state_data.get(key, str())
+            return self._cleaned_state_data.get(key)
         else:
-            return self._raw_state_data.get(key, str())
+            return self._raw_state_data.get(key)
 
     def set_datum(self, key, value, cleaned=True):
         """
         Adding data to either _raw_state_data dict or _cleaned_state_data dict
-        
+
         Arguments:
             key: key name for addition to dict
             value: data to add to dict


### PR DESCRIPTION
Note: You can see the updated reports in this build:
- https://tools-edx-jenkins.edx.org/job/Feature-Toggle-Report-Generator/job/publish-feature-toggle-report/100/

To get into the toggle state report, a CourseWaffleFlag
must have at least one of the following:
- waffle flag data
- course override data
- annotation data

Note: If a CourseWaffleFlag (in code), only has waffle
flag data, we will misreport it as a WaffleFlag until
it is annotated.

This commit adds fixes such that if the override data
or annotation data is found after the waffle flag data,
the toggle that was originally thought to be a WaffleFlag
should become a CourseWaffleFlag.

ARCHBOM-1392

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
