### PR TITLE
[BD-21] Add setting toggles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 [NOTE: None of these versions have actually been released to PyPI, even though
 the version number has been bumped.]
 
+[0.3.0] - 2020-09-23
+~~~~~~~~~~~~~~~~~~~~
+
+* Implement ``SettingToggle`` and ``SettingDictToggle``.
+
 [0.2.2] - 2020-09-11
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ requirements: ## install development environment requirements
 	pip install -qr requirements/pip-tools.txt
 	pip-sync requirements/dev.txt requirements/private.*
 
-test: clean ## run tests in the current virtualenv
+test: clean test-python ## run tests in the current virtualenv
+
+test-python: ## run all python tests
 	pytest
 
 diff_cover: test ## find diff lines that need test coverage

--- a/docs/decisions/0004-toggle-api.rst
+++ b/docs/decisions/0004-toggle-api.rst
@@ -1,0 +1,32 @@
+Feature Toggle API
+==================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+The setting toggles introduced in `ADR 0003 <../0003-django-setting-toggles>`__ will be added to this repository. In order to expose a consistent API, the public classes that should be imported from other repositories, such as ``edx-platform``, will be accessible as follows::
+
+    from edx_toggles.toggles import SettingToggle, SettingDictToggle
+
+Decision
+--------
+
+All implementation code should be moved to an ``internal`` module. The Public API will be exposed as follows in ``edx_toggles/toggles/__init__.py``::
+
+    from .internal import ...
+
+The benefits of this setup include:
+
+* A clear designation of what is part of the public API.
+* The ability to refactor the implementation without changing the API.
+* A clear reminder to developers adding new code that it needs to be exposed if it is public.
+
+Consequences
+------------
+
+Whenever a new class or function is added to the edx_toggles public API, it should be implemented in the ``internal`` module and explicitly imported in the ``edx_toggles/toggles/__init__.py`` module.

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/tests/test_toggles.py
+++ b/edx_toggles/tests/test_toggles.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""
+Unit tests that cover feature toggle functionalities.
+"""
+
+from django.test import TestCase
+
+from edx_toggles import toggles
+
+
+class SettingToggleTests(TestCase):
+    """
+    SettingToggle tests
+    """
+    def test_toggle_for_absent_setting(self):
+        toggle1 = toggles.SettingToggle("NAME1", True)
+        toggle2 = toggles.SettingToggle("NAME1", False)
+
+        self.assertTrue(toggle1.is_enabled())
+        self.assertFalse(toggle2.is_enabled())
+
+    def test_toggle_for_present_setting(self):
+        toggle1 = toggles.SettingToggle("NAME1", True)
+        toggle2 = toggles.SettingToggle("NAME1", False)
+
+        with self.settings(NAME1=42):
+            self.assertTrue(toggle1.is_enabled())
+            self.assertTrue(toggle2.is_enabled())
+
+    def test_is_enabled_is_bool(self):
+        toggle1 = toggles.SettingToggle("NAME1", 42)
+        self.assertIs(True, toggle1.is_enabled())
+
+
+class SettingDictToggleTests(TestCase):
+    """
+    SettingDictToggle tests
+    """
+    def test_toggle_for_absent_setting(self):
+        toggle1 = toggles.SettingDictToggle("NAME1", "key1", True)
+        toggle2 = toggles.SettingDictToggle("NAME2", "key2", False)
+        self.assertTrue(toggle1.is_enabled())
+        self.assertFalse(toggle2.is_enabled())
+
+    def test_toggle_for_present_setting(self):
+        toggle1 = toggles.SettingDictToggle("NAME1", "key1", True)
+
+        with self.settings(NAME1={"key1": False}):
+            self.assertFalse(toggle1.is_enabled())
+
+    def test_toggle_for_present_setting_without_key(self):
+        toggle1 = toggles.SettingDictToggle("NAME1", "key2", False)
+
+        with self.settings(NAME1={"key1": True}):
+            self.assertFalse(toggle1.is_enabled())
+
+
+class ToggleInstancesTests(TestCase):
+    """
+    Class instance-tracking tests
+    """
+    def test_created_instances(self):
+        toggle1 = toggles.SettingToggle("NAME1", default=False, module_name="module1")
+        toggle2 = toggles.SettingToggle("NAME2", default=False, module_name="module2")
+        instances = toggles.SettingToggle.get_instances()
+        self.assertEqual(2, len(instances))
+        self.assertEqual(toggle1.module_name, instances[0].module_name)
+        self.assertEqual(toggle2.module_name, instances[1].module_name)
+
+    def test_deleted_instances_are_not_listed(self):
+        toggles.SettingToggle("NAME1", default=False, module_name="module1")
+        instances = toggles.SettingToggle.get_instances()
+        self.assertEqual([], instances)

--- a/edx_toggles/toggles/__init__.py
+++ b/edx_toggles/toggles/__init__.py
@@ -1,0 +1,4 @@
+"""
+Expose public feature toggle API.
+"""
+from .internal import SettingDictToggle, SettingToggle

--- a/edx_toggles/toggles/internal.py
+++ b/edx_toggles/toggles/internal.py
@@ -1,0 +1,59 @@
+"""
+This module includes all code related to feature toggles. Remember to import publicly available classes and functions
+in __init__.py.
+"""
+
+from abc import ABC
+from weakref import WeakSet
+
+from django.conf import settings
+
+
+class BaseToggle(ABC):
+    """
+    This abstract base class exposes the basic API required by toggle classes. Toggle instances are tracked in the
+    ``_class_instances`` class attribute, which is exposed via the ``get_instaaces`` class method.
+    """
+
+    _class_instances = WeakSet()
+
+    def __init__(self, name, default=False, module_name=""):
+        self.name = name
+        self.default = default
+        self.module_name = module_name
+        self._class_instances.add(self)
+
+    def is_enabled(self):
+        raise NotImplementedError
+
+    @classmethod
+    def get_instances(cls):
+        """
+        Return the list of class instances sorted by name.
+        """
+        return sorted(cls._class_instances, key=lambda instance: instance.name)
+
+
+class SettingToggle(BaseToggle):
+    """
+    Feature toggle based on a Django setting value. Use as follows:
+
+        MY_FEATURE = SettingToggle("SETTING_NAME", default=False, module_name=__name__)
+    """
+    def is_enabled(self):
+        return bool(getattr(settings, self.name, self.default))
+
+
+class SettingDictToggle(BaseToggle):
+    """
+    Feature toggle based on the value of a key in a Django setting ``dict``. Use as follows:
+
+        MY_FEATURE = SettingDictToggle("SETTING_NAME", "key" default=False, module_name=__name__)
+    """
+    def __init__(self, name, key, default=False):
+        super().__init__(name, default=default)
+        self.key = key
+
+    def is_enabled(self):
+        setting_dict = getattr(settings, self.name, {})
+        return bool(setting_dict.get(self.key, self.default))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-"""
-Tests for the `edx-toggles` models module.
-"""

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 match-dir = (?!migrations)
 
 [pytest]
+DJANGO_SETTINGS_MODULE=test_settings
 addopts = --cov scripts --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements
 
@@ -43,7 +44,6 @@ commands =
 
 [testenv:docs]
 setenv =
-    DJANGO_SETTINGS_MODULE = test_settings
     PYTHONPATH = {toxinidir}
 whitelist_externals =
     make
@@ -66,12 +66,10 @@ whitelist_externals =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    touch tests/__init__.py
-    pylint edx_toggles tests test_utils manage.py setup.py
-    rm tests/__init__.py
-    pycodestyle edx_toggles tests manage.py setup.py
-    pydocstyle edx_toggles tests manage.py setup.py
-    isort --check-only --diff --recursive tests test_utils edx_toggles manage.py setup.py test_settings.py
+    pylint edx_toggles test_utils manage.py setup.py
+    pycodestyle edx_toggles manage.py setup.py
+    pydocstyle edx_toggles manage.py setup.py
+    isort --check-only --diff --recursive test_utils edx_toggles manage.py setup.py test_settings.py
     make selfcheck
 
 [testenv:pii_check]


### PR DESCRIPTION
**Description:** This adds a `toggles` module to the edx_toggles package. We add there
classes to store feature toggles in django settings.

These classes expose an API that is similar to those of edx-platform's
waffle_utils, such that they can be added there without too many
changes.

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943

**Dependencies:** a PR will have to be created in edx-platform to make use of this new feature

**Merge deadline:** List merge deadline (if any)

**Testing instructions:**

    make test-django

**Reviewers:**
- [ ] @robrap 
- [ ] @feanil 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)