### PR TITLE
[BD-21] Fix SettingDictToggle constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.3.1] - 2020-10-12
+~~~~~~~~~~~~~~~~~~~~
+
+* Fix ``SettingDictToggle`` constructor.
 
 [0.3.0] - 2020-09-23
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/toggles/internal.py
+++ b/edx_toggles/toggles/internal.py
@@ -50,8 +50,8 @@ class SettingDictToggle(BaseToggle):
 
         MY_FEATURE = SettingDictToggle("SETTING_NAME", "key" default=False, module_name=__name__)
     """
-    def __init__(self, name, key, default=False):
-        super().__init__(name, default=default)
+    def __init__(self, name, key, default=False, module_name=""):
+        super().__init__(name, default=default, module_name=module_name)
         self.key = key
 
     def is_enabled(self):


### PR DESCRIPTION
**Description:** The constructor was missing the `module_name` argument.

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [] ~~Documentation updated (not only docstrings)~~
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
