### PR TITLE
[BD-21] Backport `override_waffle_switch` from edx-platform

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.1.0] - 2020-10-23
+~~~~~~~~~~~~~~~~~~~~
+
+* Backport ``override_waffle_switch`` test utility function from edx-platform
+
 [1.0.0] - 2020-10-13
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/tests/test_testutils.py
+++ b/edx_toggles/tests/test_testutils.py
@@ -8,8 +8,8 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from edx_django_utils.cache import RequestCache
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
-from edx_toggles.toggles.testutils import override_waffle_flag
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 
 
 class OverrideWaffleFlagTests(TestCase):
@@ -18,7 +18,7 @@ class OverrideWaffleFlagTests(TestCase):
     """
 
     def setUp(self):
-        super(OverrideWaffleFlagTests, self).setUp()
+        super().setUp()
         namespace_name = "test_namespace"
         flag_name = "test_flag"
         self.namespaced_flag_name = namespace_name + "." + flag_name
@@ -94,3 +94,18 @@ class OverrideWaffleFlagTests(TestCase):
 
         self.assertFalse(waffle_flag1.is_enabled())
         self.assertTrue(waffle_flag2.is_enabled())
+
+
+class OverrideWaffleSwitchTests(TestCase):
+    """
+    Testt override capabilities for waffle switches.
+    """
+
+    def test_override(self):
+        namespace = WaffleSwitchNamespace("test_namespace")
+        switch = WaffleSwitch(namespace, "test_switch", module_name="testmodule")
+
+        self.assertFalse(switch.is_enabled())
+        with override_waffle_switch(switch, active=True):
+            self.assertTrue(switch.is_enabled())
+        self.assertFalse(switch.is_enabled())

--- a/edx_toggles/toggles/internal/waffle.py
+++ b/edx_toggles/toggles/internal/waffle.py
@@ -56,12 +56,38 @@ class WaffleSwitchNamespace(BaseNamespace):
         """
         Returns and caches whether the given waffle switch is enabled.
         """
+        value = self.get_request_cache(switch_name)
         namespaced_switch_name = self._namespaced_name(switch_name)
-        value = self._cached_switches.get(namespaced_switch_name)
         if value is None:
             value = switch_is_active(namespaced_switch_name)
-            self._cached_switches[namespaced_switch_name] = value
+            self.set_request_cache(namespaced_switch_name, value)
         return value
+
+    def get_request_cache(self, namespaced_switch_name, default=None):
+        """
+        API for accessing the request cache. In general, users should avoid accessing the namespace cache.
+        """
+        return self._cached_switches.get(namespaced_switch_name, default)
+
+    def get_request_cache_with_short_name(self, switch_name, default=None):
+        """
+        Compatibility method. This will be removed soon in favor of the namespaced `get_request_cache` method.
+        """
+        return self.get_request_cache(
+            self._namespaced_name(switch_name), default=default
+        )
+
+    def set_request_cache(self, namespaced_switch_name, value):
+        """
+        Manually set the request cache value. Beware! There be dragons.
+        """
+        self._cached_switches[namespaced_switch_name] = value
+
+    def set_request_cache_with_short_name(self, switch_name, value):
+        """
+        Compatibility method. This will be removed soon in favor of the namespaced `set_request_cache` method.
+        """
+        self.set_request_cache(self._namespaced_name(switch_name), value)
 
     @property
     def _cached_switches(self):

--- a/edx_toggles/toggles/testutils.py
+++ b/edx_toggles/toggles/testutils.py
@@ -74,9 +74,9 @@ class override_waffle_switch(override_switch):
         self._previous_active = self.switch.waffle_namespace.is_enabled(
             self.switch.switch_name
         )
-        self.switch.waffle_namespace._cached_switches[self.name] = self.active
+        self.switch.waffle_namespace.set_request_cache(self.switch.namespaced_switch_name, self.active)
         super().__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         super().__exit__(exc_type, exc_val, exc_tb)
-        self.switch.waffle_namespace._cached_switches[self.name] = self._previous_active
+        self.switch.waffle_namespace.set_request_cache(self.switch.namespaced_switch_name, self._previous_active)


### PR DESCRIPTION
**Description:** Backport `override_waffle_switch` from edx-platform. This utility function is used in edx-platform, but also in edx/completion.

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943

**Merge deadline:** Before https://github.com/edx/edx-platform/pull/25417

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
