### PR TITLE
[BD-21] Fix waffle switch cache checking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.1.1] - 2020-10-27
+~~~~~~~~~~~~~~~~~~~~
+
+* Fix cache-checking in WaffleSwitchNamespace
+
 [1.1.0] - 2020-10-23
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/tests/test_toggles.py
+++ b/edx_toggles/tests/test_toggles.py
@@ -97,3 +97,8 @@ class TestWaffleSwitch(TestCase):
         expected = self.NAMESPACE_NAME + "." + self.WAFFLE_SWITCH_NAME
         actual = self.WAFFLE_SWITCH.namespaced_switch_name
         self.assertEqual(actual, expected)
+
+    def test_caching(self):
+        namespace = toggles.WaffleSwitchNamespace("namespace")
+        namespace.set_request_cache_with_short_name("switch1", True)
+        self.assertTrue(namespace.is_enabled("switch1"))

--- a/edx_toggles/toggles/internal/waffle.py
+++ b/edx_toggles/toggles/internal/waffle.py
@@ -56,8 +56,8 @@ class WaffleSwitchNamespace(BaseNamespace):
         """
         Returns and caches whether the given waffle switch is enabled.
         """
-        value = self.get_request_cache(switch_name)
         namespaced_switch_name = self._namespaced_name(switch_name)
+        value = self.get_request_cache(namespaced_switch_name)
         if value is None:
             value = switch_is_active(namespaced_switch_name)
             self.set_request_cache(namespaced_switch_name, value)


### PR DESCRIPTION
**Description:** Fix waffle switch cache checking

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Dependencies:** edx-platform unit tests will fail when edx-toggles gets upgraded to 1.0.0.

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)