### PR TITLE
Updated the buld status badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.2.1] - 2020-11-16
+~~~~~~~~~~~~~~~~~~~~
+* Updated README.rst and made Build Status badge point to travis-ci.com instead of travis-ci.org
+
+
 [1.2.0] - 2020-11-05
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,8 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-toggles/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/edx-toggles.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-toggles
+.. |travis-badge| image:: https://travis-ci.com/edx/edx-toggles.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-toggles
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/edx-toggles/coverage.svg?branch=master

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089 
