### PR TITLE
[BD-21] Improve monitoring of legacy Waffle class imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.2.1] - 2020-12-17
+~~~~~~~~~~~~~~~~~~~~
+
+* Improve monitoring of legacy Waffle class imports. We should watch for "edx_toggles.toggles.internal.waffle.legacy.WaffleSwitch" custom attributes.
+
+
 [1.2.0] - 2020-11-05
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/toggles/__init__.py
+++ b/edx_toggles/toggles/__init__.py
@@ -4,8 +4,21 @@ Expose public feature toggle API.
 from .internal.setting_toggle import SettingDictToggle, SettingToggle
 from .internal.waffle.legacy import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
 
+
 # Create waffle aliases for forward compatibility
-LegacyWaffleFlag = WaffleFlag
-LegacyWaffleFlagNamespace = WaffleFlagNamespace
-LegacyWaffleSwitch = WaffleSwitch
-LegacyWaffleSwitchNamespace = WaffleSwitchNamespace
+# We create new classes instead of using `LegacyClass = Class` statements
+# for better monitoring of legacy class usage.
+class LegacyWaffleFlag(WaffleFlag):
+    pass
+
+
+class LegacyWaffleFlagNamespace(WaffleFlagNamespace):
+    pass
+
+
+class LegacyWaffleSwitch(WaffleSwitch):
+    pass
+
+
+class LegacyWaffleSwitchNamespace(WaffleSwitchNamespace):
+    pass


### PR DESCRIPTION
We should watch for "edx_toggles.toggles.waffle.internal.legacy.WaffleSwitch"
custom attributes. Wherever those occur, we should replace:

    from edx_toggles.toggles import WaffleFlag/WaffleSwitch

by:

    from edx_toggles.toggles import LegacyWaffleFlag/LegacyWaffleSwitch

This will ensure forward compatibility with edx-toggles==2.0.0.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Reviewers:**
- [ ] @robrap 


**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] ~~Documentation updated (not only docstrings)~~
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
