### PR TITLE
enhance monitoring of legacy waffle classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,15 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.2.2] - 2020-12-22
+~~~~~~~~~~~~~~~~~~~~
+
+More improvements to monitoring of legacy waffle class imports.
+
+* Add ``deprecated_incompatible_legacy_waffle_class`` custom attribute to any class (including subclasses), using the backward-incompatible imports that will be removed in 2.0.0.
+* Add ``deprecated_compatible_legacy_waffle_class`` custom attribute to any class (including subclasses) using the legacy classes compatible with 2.0.0 imports, but which should be removed in 3.0.0 (or some future major version).
+* Remove ``deprecated_edx_toggles_waffle`` custom attribute. In two cases, it was replaced by the new ``*_legacy_waffle_class`` custom attributes.  In one case, it was replaced with the already existing and more appropriate ``deprecated_waffle_legacy_method`` custom attribute.
+
 [1.2.1] - 2020-12-17
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/toggles/__init__.py
+++ b/edx_toggles/toggles/__init__.py
@@ -9,16 +9,20 @@ from .internal.waffle.legacy import WaffleFlag, WaffleFlagNamespace, WaffleSwitc
 # We create new classes instead of using `LegacyClass = Class` statements
 # for better monitoring of legacy class usage.
 class LegacyWaffleFlag(WaffleFlag):
-    pass
+    def _get_legacy_custom_attribute_name(self):
+        return 'deprecated_compatible_legacy_waffle_class'
 
 
 class LegacyWaffleFlagNamespace(WaffleFlagNamespace):
-    pass
+    def _get_legacy_custom_attribute_name(self):
+        return 'deprecated_compatible_legacy_waffle_class'
 
 
 class LegacyWaffleSwitch(WaffleSwitch):
-    pass
+    def _get_legacy_custom_attribute_name(self):
+        return 'deprecated_compatible_legacy_waffle_class'
 
 
 class LegacyWaffleSwitchNamespace(WaffleSwitchNamespace):
-    pass
+    def _get_legacy_custom_attribute_name(self):
+        return 'deprecated_compatible_legacy_waffle_class'


### PR DESCRIPTION
**Description:**

* Add ``deprecated_incompatible_legacy_waffle_class`` custom attribute
  to any class (including subclasses), using the backward-incompatible
  imports that will be removed in 2.0.0.
* Add ``deprecated_compatible_legacy_waffle_class`` custom attribute to
  any class (including subclasses) using the legacy classes compatible
  with 2.0.0 imports, but which should be removed in 3.0.0 (or some
  future major version).
* Remove ``deprecated_edx_toggles_waffle`` custom attribute. In two
  cases, it was replaced by the new ``*_legacy_waffle_class`` custom
  attributes.  In one case, it was replaced with the already
  existing and more appropriate ``deprecated_waffle_legacy_method`
  custom attribute.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)