### PR TITLE
[BD-21] Stop monitoring WaffleFlag values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.1.0] - 2021-01-12
+~~~~~~~~~~~~~~~~~~~~
+
+* Stop monitoring waffle flag values via ``WaffleFlag.set_monitor_value`` calls. The deprecated method is preserved for backward compatibility.
+
+
 [2.0.0] - 2020-11-05
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_toggles/__init__.py
+++ b/edx_toggles/__init__.py
@@ -2,6 +2,6 @@
 Library and utilities for feature toggles.
 """
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 default_app_config = 'edx_toggles.apps.TogglesConfig'  # pylint: disable=invalid-name

--- a/edx_toggles/toggles/internal/waffle/__init__.py
+++ b/edx_toggles/toggles/internal/waffle/__init__.py
@@ -21,7 +21,4 @@ To test these WaffleFlags, see edx_toggles.toggles.testutils.
 
 In the above examples, you will use Django Admin "waffle" section to configure
 for a flag named: my_namespace.some_course_feature
-
-Also see ``WAFFLE_FLAG_CUSTOM_ATTRIBUTES`` and docstring for _set_waffle_flag_attribute
-for temporarily instrumenting/monitoring waffle flag usage.
 """

--- a/edx_toggles/toggles/internal/waffle/legacy.py
+++ b/edx_toggles/toggles/internal/waffle/legacy.py
@@ -177,17 +177,15 @@ class WaffleFlagNamespace(BaseNamespace):
             self._namespaced_name(flag_name), module_name=__name__
         ).is_enabled()
 
-    def _monitor_value(self, flag_name, value):
+    def _monitor_value(self, _flag_name, _value):
         """
-        Monitoring method preserved for backward compatibility. You should use `WaffleFlag.set_monitor_value` instead.
+        Monitoring method preserved for backward compatibility. This is a no-op now that `WaffleFlag.set_monitor_value`
+        is deprecated.
         """
         set_custom_attribute(
             "deprecated_waffle_legacy_method",
             "WaffleFlagNamespace[{}]._monitor_value".format(self.name),
         )
-        return NewWaffleFlag(
-            self._namespaced_name(flag_name), module_name=__name__
-        ).set_monitor_value(value)
 
     @property
     def _cached_flags(self):

--- a/edx_toggles/toggles/internal/waffle/legacy.py
+++ b/edx_toggles/toggles/internal/waffle/legacy.py
@@ -32,7 +32,7 @@ from .flag import WaffleFlag as NewWaffleFlag
 from .switch import WaffleSwitch as NewWaffleSwitch
 
 
-class LegacyToggleMonitoringMixin():
+class LegacyToggleMonitoringMixin:
     """
     Enables monitoring of legacy waffle classes.
 
@@ -40,6 +40,7 @@ class LegacyToggleMonitoringMixin():
     imports are used. In preparation for 3.0.0, we can ensure the legacy
     classes are no longer used altogether.
     """
+
     def _set_legacy_custom_attribute(self):
         """
         Example custom attribute:
@@ -49,12 +50,14 @@ class LegacyToggleMonitoringMixin():
         set_custom_attribute(
             self._get_legacy_custom_attribute_name(),
             "{}.{}[{}]".format(
-                self.__class__.__module__, self.__class__.__name__, self.name,
-            )
+                self.__class__.__module__,
+                self.__class__.__name__,
+                self.name,
+            ),
         )
 
     def _get_legacy_custom_attribute_name(self):
-        return 'deprecated_incompatible_legacy_waffle_class'
+        return "deprecated_incompatible_legacy_waffle_class"
 
 
 class BaseNamespace(ABC, LegacyToggleMonitoringMixin):
@@ -108,7 +111,9 @@ class WaffleSwitchNamespace(BaseNamespace):
         """
         Returns whether or not the switch is enabled.
         """
-        return NewWaffleSwitch(self._namespaced_name(switch_name), __name__).is_enabled()
+        return NewWaffleSwitch(
+            self._namespaced_name(switch_name), __name__
+        ).is_enabled()
 
     def set_request_cache_with_short_name(self, switch_name, value):
         """
@@ -117,7 +122,9 @@ class WaffleSwitchNamespace(BaseNamespace):
         """
         namespaced_name = self._namespaced_name(switch_name)
         # pylint: disable=protected-access
-        NewWaffleSwitch(namespaced_name, __name__)._cached_switches[namespaced_name] = value
+        NewWaffleSwitch(namespaced_name, __name__)._cached_switches[
+            namespaced_name
+        ] = value
 
 
 class WaffleSwitch(NewWaffleSwitch, LegacyToggleMonitoringMixin):

--- a/edx_toggles/toggles/internal/waffle/switch.py
+++ b/edx_toggles/toggles/internal/waffle/switch.py
@@ -30,6 +30,7 @@ class WaffleSwitch(BaseWaffle):
     def _cached_switches(self):
         """
         Return a dictionary of all namespaced switches in the request cache.
+        Note that this property might be used elsewhere, in edx-platform for instance (although it probably shouldn't).
         """
         return _get_waffle_request_cache().setdefault("switches", {})
 


### PR DESCRIPTION
**Description:** We remove all references to the `WaffleFlag.set_monitor_value` method and the
WAFFLE_FLAG_CUSTOM_ATTRIBUTES setting, which is no longer used. This is done in a backward-compatible manner, such that existing calls to the `set_monitor_value` method can continue to exist.

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Merge deadline:** Feb 14 2021.

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] 
