### PR TITLE
Fix "toggle_type" column of Setting toggles in state report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+Unreleased
+~~~~~~~~~~
+
+* Fix ``toggle_type`` column value from the toggle state report for the ``SettingToggle`` and ``SettingDictToggle`` classes: the column is now set to "django_settings".
+
+
 [2.1.0] - 2021-01-12
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/scripts/toggles.py
+++ b/scripts/toggles.py
@@ -17,6 +17,8 @@ class ToggleTypes():
             "CourseWaffleFlag": "waffle_flags",
             "ExperimentWaffleFlag": "waffle_flags",
             "DjangoSetting": "django_settings",
+            "SettingDictToggle": "django_settings",
+            "SettingToggle": "django_settings",
             "WaffleFlag": "waffle_flags",
             "WaffleSwitch": "waffle_switches",
         }


### PR DESCRIPTION
**Description:** The toggle_type column used to be "SettingToggle" and "SettingDictToggle" for
these classes. It should instead be "django_settings".

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Merge deadline:** Feb 24 2021

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] ~~Version bumped~~
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] ~~Create a tag~~
- [ ] ~~Check new version is pushed to PyPi after tag-triggered build is finished.~~
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** :warning: THIS CHANGE IS UNTESTED. I have no idea how to generate sample json/yml reports. The project README mentions that:

> Each IDA exposes an HTTP endpoint provided by the [TODO: pending] edx-toggles Django app. A scheduled job can use an OAuth client associated with a staff user to get a JWT, and then use the JWT against each configured IDA's toggle state endpoint.

Unfortunately I have not taken the time to perform these steps. It would be great if someone could either test these changes or provide me with a sample toggle report.
