### PR TITLE
[FIX] feature_toogle_annotations.yaml reference link in how_to doc

### DIFF
--- a/docs/how_to/documenting_new_feature_toggles.rst
+++ b/docs/how_to/documenting_new_feature_toggles.rst
@@ -84,7 +84,7 @@ Additional resources
 
 For more details on the individual annotations, see `OEP-17 <https://open-edx-proposals.readthedocs.io/en/latest/oep-0017-bp-feature-toggles.html#specification>`__.
 
-The documentation format used to annotate feature toggles is stored in the code-annotations repository: `feature_toggle_annotations.yaml <https://github.com/edx/code-annotations/blob/master/code_annotations/config_and_tools/config/feature_toggle_annotations.yaml>`__.
+The documentation format used to annotate feature toggles is stored in the code-annotations repository: `feature_toggle_annotations.yaml <https://github.com/edx/code-annotations/blob/master/code_annotations/contrib/config/feature_toggle_annotations.yaml>`__.
 
 Note that all annotation fields can be wrapped on multiple lines, as long as every line after the first is prefixed by at least two empty spaces, plus the base indentation of the first line. For instance::
 


### PR DESCRIPTION
**Description:** This PR fixes the reference link of `feature_toogle_annotations.yaml` file in `how_to` documentation.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** ASAP

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @regisb 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
