### PR TITLE
fix: Handle None names annotation data.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Handle the case where certain toggle names come in as ``None`` when generating summary reports.
 
 [4.0.0] - 2021-01-24
 ~~~~~~~~~~~~~~~~~~~~

--- a/scripts/renderers.py
+++ b/scripts/renderers.py
@@ -77,7 +77,7 @@ class CsvRenderer():
 
         # sort data by either annotation_name or state_name
         # Without the `or ""` the sorting key can be None if name is set to None explicitly.
-        sorting_key = lambda datum: datum.get("name", "") or ""
+        sorting_key = lambda datum: datum.get("name") or ""
         return sorted(data_to_render, key=sorting_key)
 
     def get_sorted_headers_from_toggles(self, flattened_toggles_data, initial_header=None):

--- a/scripts/renderers.py
+++ b/scripts/renderers.py
@@ -76,7 +76,8 @@ class CsvRenderer():
                     data_to_render.append(toggle_dict)
 
         # sort data by either annotation_name or state_name
-        sorting_key = lambda datum: datum.get("name", "")
+        # Without the `or ""` the sorting key can be None if name is set to None explicitly.
+        sorting_key = lambda datum: datum.get("name", "") or ""
         return sorted(data_to_render, key=sorting_key)
 
     def get_sorted_headers_from_toggles(self, flattened_toggles_data, initial_header=None):

--- a/scripts/tests/test_renderer.py
+++ b/scripts/tests/test_renderer.py
@@ -31,6 +31,8 @@ def test_filter_and_sort_toggles_filtering():
     """
     toggle_types = ["WaffleFlag", "WaffleSwitch", "DjangoSetting"]
     names = [f"n{num}" for num in range(5*len(toggle_types))]
+    # There are cases in our real data where the name is explicitly None.  Be able to handle that case.
+    names.append(None)
     data = [{"name":name, "toggle_type":random.choice(list(toggle_types))} for name in names]
 
     # test with no filtering


### PR DESCRIPTION
More detail in the comments but there was a corner case in our data
around the sorting key being explicitly set to None.  Handle that case
as if the sorting key is not set at all.

**Merge deadline:**  None

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
