### PR TITLE
ARCHBOM-1721: docs: update toggle documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ sys.path.append(REPO_ROOT)
 VERSION = get_version('../edx_toggles', '__init__.py')
 
 # Configure Django for autodoc usage
-settings.configure()
+os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
 django_setup()
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/how_to/documenting_new_feature_toggles.rst
+++ b/docs/how_to/documenting_new_feature_toggles.rst
@@ -1,16 +1,24 @@
 .. _documenting_new_feature_toggles:
 
-=======================================
+***************************************
 How to: Documenting new feature toggles
+***************************************
+
+.. contents::
+   :depth: 1
+   :local:
+
+Purpose of feature toggle documentation
 =======================================
 
-Feature toggles are boolean values that enable or disable the use of a certain feature. There are many of those across the Open edX codebase: in the form of Django settings, Waffle flags and switches, and  Configuration models, for example. It is important that these feature toggles be correctly annotated to address the following scenarios:
+To learn more about feature toggles and how they are used and reported on, see `OEP-17: Feature Toggles`_.
 
-- Generation of human-readable documentation of existing feature toggles for Open edX operators: instead of grepping a large codebase, operators (sysadmins and product owners, for instance) should be able to search an online document to learn how to use and enable features on their platforms.
-- Issue detection and resolution at runtime: feature toggles are exposed via an API on a running platform. This allows for automated discovery of feature toggles and, for instance, comparing the state of feature toggles between different environments at runtime. Annotations will allow operators to quickly understand the nature of the discrepancies, and to address issues more efficiently.
+The documentation for feature toggles is a crucial source of information for a very wide audience, including Open edX operators, product owners and developers. The documentation will be available to developers directly in code, and extracted into a human-readable document to be used by all audiences, and especially for Open edX operators.
 
-Examples
-========
+Please keep all of these audiences in mind when crafting your documentation.
+
+Example Documentation
+=====================
 
 Boilerplate template
 --------------------
@@ -18,16 +26,16 @@ Boilerplate template
 Copy-paste this boilerplate template to document a feature toggle::
 
     # .. toggle_name: SOME_FEATURE_NAME
-    # .. toggle_implementation: WaffleFlag OR WaffleSwitch OR CourseWaffleFlag OR ExperimentWaffleFlag OR ConfigurationModel OR SettingToggle OR SettingDictToggle
+    # .. toggle_implementation: WaffleFlag OR WaffleSwitch OR CourseWaffleFlag OR ExperimentWaffleFlag OR ConfigurationModel OR SettingToggle OR SettingDictToggle OR DjangoSetting
     # .. toggle_default: True OR False
     # .. toggle_description: Add here a detailed description of the consequences of enabling this feature toggle.
     #   Note that all annotations can be spread over multiple lines by prefixing every line after the first by
-    #   at least two spaces, plus the leading space.
+    #   at least three spaces (two spaces plus the leading space).
     # .. toggle_warnings: Add here additional instructions that users should be aware of. For instance, dependency
-    #   on additional settings or feature toggles should be referenced here. If this field is not required, simply remove it.
+    #   on additional settings or feature toggles should be referenced here. If this field is not needed, simply remove it.
     # .. toggle_use_cases: temporary OR circuit_breaker OR vip OR opt_out OR opt_in OR open_edx
     # .. toggle_creation_date: 2020-01-01
-    # .. toggle_target_removal_date: 2020-07-01 (this is required if toggle_use_cases is temporary. If not, simply remove it.)
+    # .. toggle_target_removal_date: 2020-07-01 (this is required if toggle_use_cases includes temporary. If not, simply remove it.)
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TICKET-xxx OR https://github.com/edx/edx-platform/pull/xxx
     SOME_FEATURE_NAME = ...
 
@@ -53,10 +61,12 @@ Most annotation fields are self-explanatory. In this section we describe in more
 
 Must be one of the following:
 
-- "WaffleFlag", "WaffleSwitch", "CourseWaffleFlag": for objects that inherit from `waffle_utils' <https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/waffle_utils/__init__.py>`__ ``WaffleFlag``, ``WaffleSwitch`` or ``CourseWaffleFlag``, respectively.
-- "ExperimentWaffleFlag": this is for objects that inherit from ``lms.djangoapps.experiments.flags.ExperimentWaffleFlag``. See `this documentation page <https://openedx.atlassian.net/wiki/spaces/AC/pages/1250623700/Bucketing+users+for+an+experiment>`__ and the `reference implementation <https://github.com/edx/edx-platform/blob/master/lms/djangoapps/experiments/flags.py#L21>`__.
-- "ConfigurationModel": for objects that inherit from `config_models.models.ConfigurationModel <https://github.com/edx/django-config-models/>`__.
-- "SettingToggle", "SettingDictToggle": feature toggles can also be enabled by defining a `Django setting <https://docs.djangoproject.com/en/dev/topics/settings/>`__. See the relevant `ADR <https://github.com/edx/edx-toggles/blob/master/docs/decisions/0003-django-setting-toggles.rst>`__.
+- "SettingToggle", "SettingDictToggle": for objects that inherit from each of these.
+- "DjangoSetting": for boolean Django Setting toggles that do not yet use the setting toggle classes.
+- "WaffleFlag", "WaffleSwitch", "CourseWaffleFlag", "ExperimentWaffleFlag": for objects that inherit from each of these.
+- "ConfigurationModel": for objects that inherit from this.
+
+For more details. see :doc:`implement_the_right_toggle_type`.
 
 ``toggle_use_cases``
 --------------------
@@ -77,18 +87,98 @@ Temporary (``.. toggle_use_cases: temporary``):
 * Use Case 7: Opt-out/Opt-in (expected timeline: 2 years, ``.. toggle_use_cases: opt_out`` or ``.. toggle_use_cases: opt_in``)
 * Use Case 8: Open edX option (expected timeline: 3 years, ``.. toggle_use_cases: open_edx``)
 
-Note that if ``toggle_use_cases`` is "temporary" then ``toggle_target_removal_date`` **must** be defined.
+Note that if ``toggle_use_cases`` includes "temporary" then ``toggle_target_removal_date`` **must** be defined.
 
-Additional resources
-====================
+Additional details
+==================
 
-For more details on the individual annotations, see `OEP-17 <https://open-edx-proposals.readthedocs.io/en/latest/oep-0017-bp-feature-toggles.html#specification>`__.
+Multi-line annotations
+----------------------
 
-The documentation format used to annotate feature toggles is stored in the code-annotations repository: `feature_toggle_annotations.yaml <https://github.com/edx/code-annotations/blob/master/code_annotations/contrib/config/feature_toggle_annotations.yaml>`__.
-
-Note that all annotation fields can be wrapped on multiple lines, as long as every line after the first is prefixed by at least two empty spaces, plus the base indentation of the first line. For instance::
+Note that all annotation fields can be wrapped on multiple lines, as long as every line after the first is prefixed by at least three empty spaces, two spaces plus the base indentation of the first line. For instance::
 
     # .. toggle_description: line 1
     #   line2
 
+Plain-text formatting
+---------------------
+
 Note also that the annotation values will be considered as raw text and will not be parsed in any way. For instance, links and text formatting such as bold, italic or verbatim tags are currently unsupported. This might change in the future.
+
+Long-lines
+----------
+
+If you have a really long line, for example with a url that you don't want to break up, you may need to disable pylint using the following::
+
+    # .. toggle_tickets: https://some.com/long/url/that/you/dont/want/to/break/up.rst  # pylint: disable=line-too-long,useless-suppression
+
+Same toggle in multiple services
+--------------------------------
+
+If a toggle needs to be synchronized across services:
+
+* The ``toggle_description`` could state that you should read the description for the same toggle in XXX service, rather than duplicating a description.
+* The ``toggle_warnings`` should note that the value must be consistent with XXX service. XXX will often be the LMS, but not necessarily.
+
+Third-party toggles
+-------------------
+
+If we are setting a default for a toggle from a third-party library, include a link to the third-party library documentation for the toggle.
+
+Documenting legacy feature toggles
+==================================
+
+This section is specifically geared toward documenting feature toggles that were implemented in the Open edX codebase before this annotation capability existed.
+
+Research
+--------
+
+Here are a number of techniques you might use to learn about an existing toggle. Please add any helpful background links to the PR description of the PR that is adding the annotation.
+
+* Use ``git blame`` or ``git log search`` (a.k.a. pickaxe).
+* Search the `deprecated feature flag documentation in Confluence`_.
+* Search the `additional reference tab`_ of the toggle docathon spreadsheet.
+* When not a security concern, asking edX.org to compare its Production setting to the default can sometimes shed some light.
+
+.. _deprecated feature flag documentation in Confluence: https://openedx.atlassian.net/wiki/spaces/AC/pages/34734726/edX+Feature+Flags
+.. _additional reference tab: https://docs.google.com/spreadsheets/d/1xWbEL6oNu6D84WKBs3aViLRM40xk-vmnmmGAeLyR09A/edit?ts=6008a109#gid=1700780514
+
+Bias toward temporary use case
+------------------------------
+
+As detailed in `OEP-17: Feature Toggles`_, the fewer feature toggles the better.
+
+If it is unclear whether or not a toggle was meant to be temporary or permanent:
+
+* Use the ``temporary`` use case.
+* Feel free to note your uncertainty in the description.
+* Use a target removal date of 3 months after the creation date. It is ok if this date has passed.
+
+Hopefully this can trigger our DEPR(ecation) process, so we can learn whether or not it really can be removed.
+
+Refactor to use new toggle setting classes
+------------------------------------------
+
+Undocumented boolean Django Setting toggles defined in the Open edX codebase are probably not yet defined using a ``SettingToggle`` or ``SettingDictToggle``. Read about implementing these toggle classes in :doc:`implement_the_right_toggle_type`.
+
+Refactor LegacyWaffle classes
+------------------------------
+
+* Import ``WaffleFlag`` instead of ``LegacyWaffleFlag`` or ``WaffleSwitch`` instead of ``LegacyWaffleSwitch``.
+* Initialize these new classes with a single string that includes the fully namespaced toggle name, including the period.
+
+Refactor direct waffle usage
+----------------------------
+
+Replace ``waffle.flag_is_active`` with a new documented ``WaffleFlag``, or ``waffle.switch_is_active`` with a new documented ``WaffleSwitch``.
+
+If the flag or switch name is not namespaced (i.e. doesn't contain a ``.``), use the ``NonNamespacedWaffleFlag`` or ``NonNamespacedWaffleSwitch`` class. All newly defined feature toggles should be namespaced, so these classes only support legacy toggles.
+
+Additional resources
+====================
+
+For more details on the individual annotations, see `OEP-17: Feature Toggles`_.
+
+.. _`OEP-17: Feature Toggles`: https://open-edx-proposals.readthedocs.io/en/latest/oep-0017-bp-feature-toggles.html
+
+The documentation format used to annotate feature toggles is stored in the code-annotations repository: `feature_toggle_annotations.yaml <https://github.com/edx/code-annotations/blob/master/code_annotations/contrib/config/feature_toggle_annotations.yaml>`__.

--- a/docs/how_to/implement_the_right_toggle_type.rst
+++ b/docs/how_to/implement_the_right_toggle_type.rst
@@ -1,0 +1,90 @@
+***************************************
+How to: Implement the right toggle type
+***************************************
+
+First choose the general type of toggle and then the more specific implementation below.
+
+.. contents::
+   :depth: 1
+   :local:
+
+Choosing the general toggle type
+================================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 60 5 5 15
+
+   * - type
+     - description
+     - config as data
+     - config as code
+     - beyond on/off
+   * - Boolean Django Settings
+     - Boolean Django Settings are simple on/off toggles. At edX, this would be set and deployed via remote config.
+     -
+     - X
+     -
+   * - Waffle Switches
+     - Waffle switches are simple on/off toggles. These are configured through Django admin.
+     - X
+     -
+     -
+   * - Waffle Flags
+     - Waffle flags are on/off toggles with a variety of other capabilities, such as percent rollout, setting for individual users or courses, etc. These are configured through Django admin.
+     - X
+     -
+     - Percent rollout, setting by user or course, potentially handles A/B experiments.
+   * - Config Models with Boolean Fields
+     - Config models enable more complex configuration models with audit capabilities. Like Django Settings, config models would only contain toggles if it contained boolean fields. These are configured through Django admin.
+     - X
+     -
+     -
+
+Implementing the right toggle type
+==================================
+
+Django Setting toggles
+----------------------
+
+Use the `SettingToggle and SettingDictToggle classes`_ to implement toggles based on a Django Setting. This new class should be added to the Django app that most closely relates to the setting. See the `ADR for the Setting Toggle classes`_ to understand the advantages over using the Django Setting directly.
+
+If the toggle is being added to edx-platform, and it needs to be used by both LMS and Studio, you can add it to ``openedx/core/toggles.py``.
+
+Avoid referring to boolean Django Settings directly. However, if a boolean setting toggle is implemented without one of the wrapping classes, its annotation implementation would be `DjangoSetting`.
+
+.. _SettingToggle and SettingDictToggle classes: https://github.com/edx/edx-toggles/blob/master/edx_toggles/toggles/internal/setting_toggle.py
+.. _ADR for the Setting Toggle classes: ../decisions/0003-django-setting-toggles.html
+
+Waffle Switches
+---------------
+
+Use the `WaffleSwitch class`_, a wrapper around the `waffle`_ switch.
+
+If you are wrapping a legacy switch that does not have a namespaced name (i.e. no ``.`` in the name), use the ``NonNamespacedWaffleSwitch`` instead.
+
+.. _WaffleSwitch class: ../edx_toggles.toggles.internal.waffle.html#module-edx_toggles.toggles.internal.waffle
+
+Waffle Flags
+------------
+
+For the basic capabilities, use the `WaffleFlag class`_, a wrapper around the `waffle`_ flag.
+
+If you are wrapping a legacy flag that does not have a namespaced name (i.e. no ``.`` in the name), use the ``NonNamespacedWaffleFlag`` instead.
+
+In edx-platform, there is also:
+
+* `CourseWaffleFlag`_: A WaffleFlag that adds override capabilities per course.
+* `ExperimentWaffleFlag`_: A somewhat complex CourseWaffleFlag that enables bucketing of users for A/B experiments.
+
+.. _WaffleFlag class: ../edx_toggles.toggles.internal.waffle.html#module-edx_toggles.toggles.internal.waffle
+.. _waffle: https://waffle.readthedocs.io/
+.. _CourseWaffleFlag: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/waffle_utils/__init__.py
+.. _ExperimentWaffleFlag: https://github.com/edx/edx-platform/blob/master/lms/djangoapps/experiments/flags.py
+
+Config Models
+--------------
+
+A `ConfigurationModel`_ can be used if all other options do not suit your needs. In most cases, it is no longer necessary.
+
+.. _ConfigurationModel: https://github.com/edx/django-config-models/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Library and utilities for feature toggles
    :caption: How-Tos
 
    how_to/documenting_new_feature_toggles
+   how_to/implement_the_right_toggle_type
    how_to/create_toggles_report_for_devstack_or_sandbox.rst
    how_to/adding_new_ida_to_toggle_report
    how_to/get_feature_toggles_annotation_data.rst

--- a/edx_toggles/toggles/internal/waffle/__init__.py
+++ b/edx_toggles/toggles/internal/waffle/__init__.py
@@ -7,7 +7,7 @@ For waffle flags::
 
     SOME_FLAG = WaffleFlag('some_namespace_prefix.some_feature', module_name=__name__)
 
-For waffle switches:
+For waffle switches::
 
     SOME_SWITCH = WaffleSwitch('some_namespace_prefix.some_feature', module_name=__name__)
 


### PR DESCRIPTION
**Description:**

fix: django package docs

The proper Django Settings were not getting used when building
docs, which caused certain modules to not build in the package
docs.

docs: update toggle documentation

* Enhance documenting_new_feature_toggles.rst.
* Add implement_the_right_toggle_type.rst.

Note: Some of the documentation ideas come from the [Docathon docs on Confluence](https://openedx.atlassian.net/wiki/spaces/AC/pages/2248409171/Toggles+and+Settings+Doc-a-thon+2021).

**Testing:**

* See this branch on readthedocs: https://draft-edx-toggles.readthedocs.io/en/latest/
  * See the [broken production readthedocs for the state report module](https://edx.readthedocs.io/projects/edx-toggles/en/latest/edx_toggles.toggles.state.internal.html#edx-toggles-toggles-state-internal-report-module).
  * See the [working branch draft readthedocs for the state report module](https://draft-edx-toggles.readthedocs.io/en/latest//edx_toggles.toggles.state.internal.html#edx-toggles-toggles-state-internal-report-module).

**JIRA:**

ARCHBOM-1721

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post-merge checklist:**
- [ ] Add doc config fix to cookie-cutter.